### PR TITLE
[iOS #50 (REFACTOR)] 의존성 주입을 위한 coordinator 패턴 적용

### DIFF
--- a/iOS/project04/project04.xcodeproj/project.pbxproj
+++ b/iOS/project04/project04.xcodeproj/project.pbxproj
@@ -36,6 +36,11 @@
 		C1900D7E256B85ED0071E8C7 /* DetailListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1900D7D256B85ED0071E8C7 /* DetailListViewController.swift */; };
 		C1900D88256B8E220071E8C7 /* Detail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1900D87256B8E220071E8C7 /* Detail.swift */; };
 		C1900D8C256B910F0071E8C7 /* DetailListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1900D8B256B910F0071E8C7 /* DetailListViewModel.swift */; };
+		C1E6C40E2574D27900BD4B4B /* BucketList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C1E6C40D2574D27900BD4B4B /* BucketList.storyboard */; };
+		C1E6C4122574D31300BD4B4B /* DetailList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C1E6C4112574D31300BD4B4B /* DetailList.storyboard */; };
+		C1E6C4172574D45900BD4B4B /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E6C4162574D45900BD4B4B /* MainTabBarController.swift */; };
+		C1E6C41B2574D4BE00BD4B4B /* BucketCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E6C41A2574D4BE00BD4B4B /* BucketCoordinator.swift */; };
+		C1E6C41F2574E83200BD4B4B /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E6C41E2574E83200BD4B4B /* NavigationCoordinator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -83,6 +88,11 @@
 		C1900D7D256B85ED0071E8C7 /* DetailListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailListViewController.swift; sourceTree = "<group>"; };
 		C1900D87256B8E220071E8C7 /* Detail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Detail.swift; path = project04/Model/Detail.swift; sourceTree = SOURCE_ROOT; };
 		C1900D8B256B910F0071E8C7 /* DetailListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DetailListViewModel.swift; path = project04/Scene/DetailList/ViewModel/DetailListViewModel.swift; sourceTree = SOURCE_ROOT; };
+		C1E6C40D2574D27900BD4B4B /* BucketList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = BucketList.storyboard; sourceTree = "<group>"; };
+		C1E6C4112574D31300BD4B4B /* DetailList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = DetailList.storyboard; sourceTree = "<group>"; };
+		C1E6C4162574D45900BD4B4B /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
+		C1E6C41A2574D4BE00BD4B4B /* BucketCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketCoordinator.swift; sourceTree = "<group>"; };
+		C1E6C41E2574E83200BD4B4B /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
 		EA43E93461629E8CD0B41E3B /* Pods-project04.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-project04.debug.xcconfig"; path = "Target Support Files/Pods-project04/Pods-project04.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -181,6 +191,7 @@
 			children = (
 				C1655CA2256B7ED30067E3C5 /* Info.plist */,
 				C11AC45F256B7F8B00E45667 /* .swiftlint.yml */,
+				C1E6C4152574D41600BD4B4B /* Coordinator */,
 				C1900D79256B84C70071E8C7 /* App */,
 				C1900D77256B83970071E8C7 /* Scene */,
 				C1900D74256B82840071E8C7 /* Model */,
@@ -193,6 +204,7 @@
 			isa = PBXGroup;
 			children = (
 				C1900D7D256B85ED0071E8C7 /* DetailListViewController.swift */,
+				C1E6C4112574D31300BD4B4B /* DetailList.storyboard */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -201,6 +213,7 @@
 			isa = PBXGroup;
 			children = (
 				C1655C98256B7ED10067E3C5 /* BucketListViewController.swift */,
+				C1E6C40D2574D27900BD4B4B /* BucketList.storyboard */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -322,6 +335,16 @@
 			path = DetailList;
 			sourceTree = "<group>";
 		};
+		C1E6C4152574D41600BD4B4B /* Coordinator */ = {
+			isa = PBXGroup;
+			children = (
+				C1E6C4162574D45900BD4B4B /* MainTabBarController.swift */,
+				C1E6C41A2574D4BE00BD4B4B /* BucketCoordinator.swift */,
+				C1E6C41E2574E83200BD4B4B /* NavigationCoordinator.swift */,
+			);
+			path = Coordinator;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -406,6 +429,8 @@
 			files = (
 				C11AC460256B7F8B00E45667 /* .swiftlint.yml in Resources */,
 				C1655CA1256B7ED30067E3C5 /* LaunchScreen.storyboard in Resources */,
+				C1E6C40E2574D27900BD4B4B /* BucketList.storyboard in Resources */,
+				C1E6C4122574D31300BD4B4B /* DetailList.storyboard in Resources */,
 				C1655C9E256B7ED30067E3C5 /* Assets.xcassets in Resources */,
 				C1655C9C256B7ED10067E3C5 /* Main.storyboard in Resources */,
 			);
@@ -469,9 +494,11 @@
 			files = (
 				C1655C99256B7ED10067E3C5 /* BucketListViewController.swift in Sources */,
 				82A72917256F43E100BD5797 /* BucketLocalAgent.swift in Sources */,
+				C1E6C4172574D45900BD4B4B /* MainTabBarController.swift in Sources */,
 				C1754F07256E4AC00037C805 /* ListUseCase.swift in Sources */,
 				C1754EF1256E1A570037C805 /* NetworkError.swift in Sources */,
 				82A7291B256F448100BD5797 /* BucketAPIAgent.swift in Sources */,
+				C1E6C41B2574D4BE00BD4B4B /* BucketCoordinator.swift in Sources */,
 				C175D190256CC028001144F0 /* DetailListUseCase.swift in Sources */,
 				C1655C95256B7ED10067E3C5 /* AppDelegate.swift in Sources */,
 				C1900D88256B8E220071E8C7 /* Detail.swift in Sources */,
@@ -481,6 +508,7 @@
 				C175D194256CC2EC001144F0 /* DetailAPIAgent.swift in Sources */,
 				C1655C97256B7ED10067E3C5 /* SceneDelegate.swift in Sources */,
 				C175D19B256CCF3C001144F0 /* RealmDetailList.swift in Sources */,
+				C1E6C41F2574E83200BD4B4B /* NavigationCoordinator.swift in Sources */,
 				C1754EEC256E197C0037C805 /* NetworkService.swift in Sources */,
 				C1754EF5256E1B8B0037C805 /* HTTPMethod.swift in Sources */,
 				8259AAF9256B9C19006698FC /* Bucket.swift in Sources */,

--- a/iOS/project04/project04/App/SceneDelegate.swift
+++ b/iOS/project04/project04/App/SceneDelegate.swift
@@ -16,7 +16,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        window = UIWindow(windowScene: windowScene)
+        let controller = MainTabBarController()
+        window?.rootViewController = controller
+        window?.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/iOS/project04/project04/Coordinator/BucketCoordinator.swift
+++ b/iOS/project04/project04/Coordinator/BucketCoordinator.swift
@@ -1,0 +1,36 @@
+//
+//  BucketCoordinator.swift
+//  project04
+//
+//  Created by 남기범 on 2020/11/30.
+//
+
+import Foundation
+import UIKit
+
+protocol DetailListPushCoordinator {
+    func pushToDetailList(bucket: RealmBucket?)
+}
+
+final class BucketCoordinator: NavigationCoordinator {
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func pushViewController() {
+        let viewController = UIStoryboard(name: "BucketList", bundle: nil).instantiateViewController(identifier: "BucketListViewController") as BucketListViewController
+        viewController.coordinator = self
+        navigationController.navigationBar.prefersLargeTitles = true
+        navigationController.pushViewController(viewController, animated: false)
+    }
+}
+
+extension BucketCoordinator: DetailListPushCoordinator {
+    func pushToDetailList(bucket: RealmBucket?) {
+        let viewController = UIStoryboard(name: "DetailList", bundle: nil).instantiateViewController(identifier: "DetailListViewController") as DetailListViewController
+        viewController.bucket = bucket
+        navigationController.pushViewController(viewController, animated: true)
+    }
+}

--- a/iOS/project04/project04/Coordinator/MainTabBarController.swift
+++ b/iOS/project04/project04/Coordinator/MainTabBarController.swift
@@ -1,0 +1,23 @@
+//
+//  MainTabBarController.swift
+//  project04
+//
+//  Created by 남기범 on 2020/11/30.
+//
+
+import Foundation
+import UIKit
+
+final class MainTabBarController: UITabBarController {
+    let bucketList = BucketCoordinator(navigationController: UINavigationController())
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupViewControllers()
+    }
+    
+    private func setupViewControllers() {
+        bucketList.pushViewController()
+        viewControllers = [bucketList.navigationController]
+    }
+}

--- a/iOS/project04/project04/Coordinator/NavigationCoordinator.swift
+++ b/iOS/project04/project04/Coordinator/NavigationCoordinator.swift
@@ -1,0 +1,14 @@
+//
+//  NavigationCoordinator.swift
+//  project04
+//
+//  Created by 남기범 on 2020/11/30.
+//
+
+import Foundation
+import UIKit
+
+protocol NavigationCoordinator {
+    var navigationController: UINavigationController { get set }
+    func pushViewController()
+}

--- a/iOS/project04/project04/Scene/BucketList/View/BucketList.storyboard
+++ b/iOS/project04/project04/Scene/BucketList/View/BucketList.storyboard
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BOR-i1-Tgp">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--버킷 리스트-->
+        <scene sceneID="Yxs-GF-apX">
+            <objects>
+                <viewController storyboardIdentifier="BucketListViewController" id="BOR-i1-Tgp" customClass="BucketListViewController" customModule="project04" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Evh-no-OW1">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Phn-4f-ViY">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Rfz-2u-hhx">
+                                    <size key="itemSize" width="414" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="collectionViewCell" id="4qd-nt-faQ">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="k0e-aV-Ae3">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </collectionViewCellContentView>
+                                        <size key="customSize" width="414" height="128"/>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="Ozg-fG-xrh"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Phn-4f-ViY" firstAttribute="leading" secondItem="Evh-no-OW1" secondAttribute="leading" id="FSE-L0-E2X"/>
+                            <constraint firstAttribute="bottom" secondItem="Phn-4f-ViY" secondAttribute="bottom" id="MSV-YF-Z5y"/>
+                            <constraint firstItem="Phn-4f-ViY" firstAttribute="top" secondItem="Evh-no-OW1" secondAttribute="top" id="RfB-SP-0ia"/>
+                            <constraint firstAttribute="trailing" secondItem="Phn-4f-ViY" secondAttribute="trailing" id="nyi-RJ-WXK"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="버킷 리스트" largeTitleDisplayMode="always" id="Q7P-zt-yhr">
+                        <barButtonItem key="rightBarButtonItem" image="plus" catalog="system" id="XWm-ZF-uZO">
+                            <connections>
+                                <action selector="didTouchPlusButton:" destination="BOR-i1-Tgp" id="6xl-mc-XVz"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="collectionView" destination="Phn-4f-ViY" id="xWN-Q2-Mfs"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="lGX-Dr-gs2" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2708.6956521739135" y="103.79464285714285"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="plus" catalog="system" width="128" height="113"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/iOS/project04/project04/Scene/BucketList/View/BucketListViewController.swift
+++ b/iOS/project04/project04/Scene/BucketList/View/BucketListViewController.swift
@@ -13,6 +13,7 @@ class BucketListViewController: UIViewController {
     typealias Snapshot = NSDiffableDataSourceSnapshot<Bucket.Section, Bucket>
     var dataSource: DataSource?
     var bucketListViewModel: BucketListViewModel?
+    var coordinator: DetailListPushCoordinator?
     @IBOutlet weak var collectionView: UICollectionView!
     
     override func viewDidLoad() {
@@ -120,7 +121,13 @@ extension BucketListViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let bucket = dataSource?.itemIdentifier(for: indexPath)
-        performSegue(withIdentifier: "DetailListSegue", sender: bucket)
+        do {
+            let realm = try Realm()
+            let realmBucket = realm.objects(RealmBucket.self).filter { $0.id == bucket?.id }
+            coordinator?.pushToDetailList(bucket: realmBucket.first)
+        } catch {
+            print(error)
+        }
     }
 }
 

--- a/iOS/project04/project04/Scene/DetailList/View/DetailList.storyboard
+++ b/iOS/project04/project04/Scene/DetailList/View/DetailList.storyboard
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ns3-L0-UQH">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--세부 리스트-->
+        <scene sceneID="Ghh-fP-5wt">
+            <objects>
+                <viewController storyboardIdentifier="DetailListViewController" id="ns3-L0-UQH" customClass="DetailListViewController" customModule="project04" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="vUg-8j-eCj">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="o0k-aT-7Pv">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="ECs-8f-vSf">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="detailCell" id="gO9-qg-Uu9">
+                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="h8X-22-NaA">
+                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </collectionViewCellContentView>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="bx9-gL-be4"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="o0k-aT-7Pv" firstAttribute="top" secondItem="vUg-8j-eCj" secondAttribute="top" id="N7B-ME-Xfb"/>
+                            <constraint firstAttribute="bottom" secondItem="o0k-aT-7Pv" secondAttribute="bottom" id="TKM-Bi-Q73"/>
+                            <constraint firstItem="o0k-aT-7Pv" firstAttribute="leading" secondItem="bx9-gL-be4" secondAttribute="leading" id="cNc-3n-gbI"/>
+                            <constraint firstItem="bx9-gL-be4" firstAttribute="trailing" secondItem="o0k-aT-7Pv" secondAttribute="trailing" id="os0-Ha-S4M"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="세부 리스트" id="43o-mz-SIf">
+                        <barButtonItem key="rightBarButtonItem" title="Item" image="plus" catalog="system" id="yuN-Zh-bt4">
+                            <connections>
+                                <action selector="detailAppendAction:" destination="ns3-L0-UQH" id="e3B-4C-WK8"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="collectionView" destination="o0k-aT-7Pv" id="5UN-Eq-PkU"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="fAT-Jr-sL1" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2645" y="104"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="plus" catalog="system" width="128" height="113"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>


### PR DESCRIPTION
## 구현의도
- ViewController 재사용 및 의존성 주입을 위해 coordinator 패턴을 사용하게 되었습니다.
- main.storyboard가 무거워지는 것을 방지하기 위해 storyboard를 분할하였습니다. 

## 기능 흐름도, 클래스 다이어그램(선택사항)
<img width="1192" alt="coordinator2" src="https://user-images.githubusercontent.com/31726630/100593150-66759100-333b-11eb-963c-a641056d9e6b.png">


## 사용된 기술
- Coordinator 패턴

## 리뷰요청 & 논의사항 & 궁금한점
- 현재 viewController를 초기에 navigationController에 push할 때, 용도 그대로 pushController라는 함수명을 사용했는데, 이걸 위에 다이어그램을 보면 start로 표현하는 것 같아요. 이걸 그대로 따라가야만하는지 궁금하네요 