### PR TITLE
[iOS #60] detail List 생성 화면 레이아웃 구현

### DIFF
--- a/iOS/project04/project04.xcodeproj/project.pbxproj
+++ b/iOS/project04/project04.xcodeproj/project.pbxproj
@@ -28,6 +28,9 @@
 		C1754EF1256E1A570037C805 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1754EF0256E1A570037C805 /* NetworkError.swift */; };
 		C1754EF5256E1B8B0037C805 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1754EF4256E1B8B0037C805 /* HTTPMethod.swift */; };
 		C1754F07256E4AC00037C805 /* ListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1754F06256E4AC00037C805 /* ListUseCase.swift */; };
+		C175AA7825752C57009D8103 /* DetailListAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C175AA7725752C57009D8103 /* DetailListAddViewController.swift */; };
+		C175AA7C25752C7D009D8103 /* DetailListAdd.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C175AA7B25752C7D009D8103 /* DetailListAdd.storyboard */; };
+		C175AA8025752F72009D8103 /* DetailAddCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C175AA7F25752F72009D8103 /* DetailAddCoordinator.swift */; };
 		C175D190256CC028001144F0 /* DetailListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C175D18F256CC028001144F0 /* DetailListUseCase.swift */; };
 		C175D194256CC2EC001144F0 /* DetailAPIAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C175D193256CC2EC001144F0 /* DetailAPIAgent.swift */; };
 		C175D197256CC31C001144F0 /* DetailLocalAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C175D196256CC31C001144F0 /* DetailLocalAgent.swift */; };
@@ -78,6 +81,9 @@
 		C1754EF0256E1A570037C805 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		C1754EF4256E1B8B0037C805 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		C1754F06256E4AC00037C805 /* ListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListUseCase.swift; sourceTree = "<group>"; };
+		C175AA7725752C57009D8103 /* DetailListAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailListAddViewController.swift; sourceTree = "<group>"; };
+		C175AA7B25752C7D009D8103 /* DetailListAdd.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = DetailListAdd.storyboard; sourceTree = "<group>"; };
+		C175AA7F25752F72009D8103 /* DetailAddCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailAddCoordinator.swift; sourceTree = "<group>"; };
 		C175D18F256CC028001144F0 /* DetailListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailListUseCase.swift; sourceTree = "<group>"; };
 		C175D193256CC2EC001144F0 /* DetailAPIAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailAPIAgent.swift; sourceTree = "<group>"; };
 		C175D196256CC31C001144F0 /* DetailLocalAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailLocalAgent.swift; sourceTree = "<group>"; };
@@ -205,6 +211,8 @@
 			children = (
 				C1900D7D256B85ED0071E8C7 /* DetailListViewController.swift */,
 				C1E6C4112574D31300BD4B4B /* DetailList.storyboard */,
+				C175AA7725752C57009D8103 /* DetailListAddViewController.swift */,
+				C175AA7B25752C7D009D8103 /* DetailListAdd.storyboard */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -340,6 +348,7 @@
 			children = (
 				C1E6C4162574D45900BD4B4B /* MainTabBarController.swift */,
 				C1E6C41A2574D4BE00BD4B4B /* BucketCoordinator.swift */,
+				C175AA7F25752F72009D8103 /* DetailAddCoordinator.swift */,
 				C1E6C41E2574E83200BD4B4B /* NavigationCoordinator.swift */,
 			);
 			path = Coordinator;
@@ -432,6 +441,7 @@
 				C1E6C40E2574D27900BD4B4B /* BucketList.storyboard in Resources */,
 				C1E6C4122574D31300BD4B4B /* DetailList.storyboard in Resources */,
 				C1655C9E256B7ED30067E3C5 /* Assets.xcassets in Resources */,
+				C175AA7C25752C7D009D8103 /* DetailListAdd.storyboard in Resources */,
 				C1655C9C256B7ED10067E3C5 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -493,6 +503,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				C1655C99256B7ED10067E3C5 /* BucketListViewController.swift in Sources */,
+				C175AA8025752F72009D8103 /* DetailAddCoordinator.swift in Sources */,
+				C175AA7825752C57009D8103 /* DetailListAddViewController.swift in Sources */,
 				82A72917256F43E100BD5797 /* BucketLocalAgent.swift in Sources */,
 				C1E6C4172574D45900BD4B4B /* MainTabBarController.swift in Sources */,
 				C1754F07256E4AC00037C805 /* ListUseCase.swift in Sources */,

--- a/iOS/project04/project04/Coordinator/BucketCoordinator.swift
+++ b/iOS/project04/project04/Coordinator/BucketCoordinator.swift
@@ -15,7 +15,7 @@ protocol DetailListPushCoordinator {
 final class BucketCoordinator: NavigationCoordinator {
     var navigationController: UINavigationController
     
-    init(navigationController: UINavigationController) {
+    init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
     }
     
@@ -31,6 +31,7 @@ extension BucketCoordinator: DetailListPushCoordinator {
     func pushToDetailList(bucket: RealmBucket?) {
         let viewController = UIStoryboard(name: "DetailList", bundle: nil).instantiateViewController(identifier: "DetailListViewController") as DetailListViewController
         viewController.bucket = bucket
+        viewController.coordinator = DetailAddCoordinator(navigationController)
         configureDetailListViewModel(viewController)
         navigationController.pushViewController(viewController, animated: true)
     }

--- a/iOS/project04/project04/Coordinator/BucketCoordinator.swift
+++ b/iOS/project04/project04/Coordinator/BucketCoordinator.swift
@@ -31,6 +31,16 @@ extension BucketCoordinator: DetailListPushCoordinator {
     func pushToDetailList(bucket: RealmBucket?) {
         let viewController = UIStoryboard(name: "DetailList", bundle: nil).instantiateViewController(identifier: "DetailListViewController") as DetailListViewController
         viewController.bucket = bucket
+        configureDetailListViewModel(viewController)
         navigationController.pushViewController(viewController, animated: true)
+    }
+    
+    func configureDetailListViewModel(_ viewController: DetailListViewController) {
+        let networkAgent = DetailAPIAgent()
+        let localAgent = DetailLocalAgent()
+        localAgent.bucket = viewController.bucket
+        let repository = DetailRepository(network: networkAgent, local: localAgent)
+        let usecase = DetailListUseCase(repository: repository)
+        viewController.collectionViewModel = DetailListViewModel(usecase: usecase)
     }
 }

--- a/iOS/project04/project04/Coordinator/DetailAddCoordinator.swift
+++ b/iOS/project04/project04/Coordinator/DetailAddCoordinator.swift
@@ -1,0 +1,22 @@
+//
+//  DetailListAddCoordinator.swift
+//  project04
+//
+//  Created by 남기범 on 2020/11/30.
+//
+
+import Foundation
+import UIKit
+
+class DetailAddCoordinator: NavigationCoordinator {
+    var navigationController: UINavigationController
+    
+    required init(_ navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func presentDetailListAdd(_ navigationController: UINavigationController?) {
+        let viewController = UIStoryboard(name: "DetailListAdd", bundle: nil).instantiateViewController(identifier: "DetailListAddViewController") as DetailListAddViewController
+        navigationController?.present(viewController, animated: false)
+    }
+}

--- a/iOS/project04/project04/Coordinator/MainTabBarController.swift
+++ b/iOS/project04/project04/Coordinator/MainTabBarController.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 final class MainTabBarController: UITabBarController {
-    let bucketList = BucketCoordinator(navigationController: UINavigationController())
+    let bucketList = BucketCoordinator(UINavigationController())
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/iOS/project04/project04/Coordinator/NavigationCoordinator.swift
+++ b/iOS/project04/project04/Coordinator/NavigationCoordinator.swift
@@ -10,5 +10,5 @@ import UIKit
 
 protocol NavigationCoordinator {
     var navigationController: UINavigationController { get set }
-    func pushViewController()
+    init(_ navigationController: UINavigationController)
 }

--- a/iOS/project04/project04/Scene/DetailList/View/DetailListAdd.storyboard
+++ b/iOS/project04/project04/Scene/DetailList/View/DetailListAdd.storyboard
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="du0-2n-SY7">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Detail List Add View Controller-->
+        <scene sceneID="bGW-38-mkV">
+            <objects>
+                <viewController storyboardIdentifier="DetailListAddViewController" modalPresentationStyle="overFullScreen" id="du0-2n-SY7" customClass="DetailListAddViewController" customModule="project04" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="zh4-qb-4tc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eGV-TC-1mb">
+                                <rect key="frame" x="0.0" y="836" width="414" height="60"/>
+                                <subviews>
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="PDm-eO-kYM">
+                                        <rect key="frame" x="18" y="8" width="378" height="44"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <color key="textColor" systemColor="labelColor"/>
+                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                    </textView>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="PDm-eO-kYM" secondAttribute="trailing" constant="18" id="Fv1-AQ-UTC"/>
+                                    <constraint firstItem="PDm-eO-kYM" firstAttribute="top" secondItem="eGV-TC-1mb" secondAttribute="top" constant="8" id="MUI-Pe-QFa"/>
+                                    <constraint firstAttribute="height" priority="999" constant="60" id="QHc-7N-i2v"/>
+                                    <constraint firstItem="PDm-eO-kYM" firstAttribute="leading" secondItem="eGV-TC-1mb" secondAttribute="leading" constant="18" id="i32-Rb-teG"/>
+                                    <constraint firstAttribute="bottom" secondItem="PDm-eO-kYM" secondAttribute="bottom" constant="8" id="kL1-fC-Ovl"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="2gG-md-Aaf"/>
+                        <color key="backgroundColor" red="0.84087484137055835" green="0.84087484137055835" blue="0.84087484137055835" alpha="0.65041738013698636" colorSpace="custom" customColorSpace="displayP3"/>
+                        <constraints>
+                            <constraint firstItem="eGV-TC-1mb" firstAttribute="trailing" secondItem="2gG-md-Aaf" secondAttribute="trailing" id="3cH-kh-Jtf"/>
+                            <constraint firstAttribute="bottom" secondItem="eGV-TC-1mb" secondAttribute="bottom" id="NlH-ac-tUN"/>
+                            <constraint firstItem="eGV-TC-1mb" firstAttribute="top" relation="greaterThanOrEqual" secondItem="2gG-md-Aaf" secondAttribute="top" id="a2h-mp-CN1"/>
+                            <constraint firstItem="eGV-TC-1mb" firstAttribute="leading" secondItem="2gG-md-Aaf" secondAttribute="leading" id="j6u-uy-NHr"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="heightConstraint" destination="QHc-7N-i2v" id="qQK-Yx-hZe"/>
+                        <outlet property="textView" destination="PDm-eO-kYM" id="e5U-EB-SGl"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="wxA-4o-nH1" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="259.4202898550725" y="132.58928571428572"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/iOS/project04/project04/Scene/DetailList/View/DetailListAddViewController.swift
+++ b/iOS/project04/project04/Scene/DetailList/View/DetailListAddViewController.swift
@@ -1,0 +1,73 @@
+//
+//  DetailListAddViewController.swift
+//  project04
+//
+//  Created by 남기범 on 2020/11/30.
+//
+
+import UIKit
+
+class DetailListAddViewController: UIViewController {
+    @IBOutlet weak var textView: UITextView!
+    @IBOutlet weak var heightConstraint: NSLayoutConstraint!
+    var contentSize: CGFloat = 37
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow(_:)),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide(_:)),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+        
+        textView.delegate = self
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        textView.becomeFirstResponder()
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
+    }
+
+    @objc func keyboardWillShow(_ notification:NSNotification) {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardRectangle = keyboardFrame.cgRectValue
+            let keyboardHeight = keyboardRectangle.height
+            
+            self.view.frame.origin.y = -keyboardHeight
+        }
+    }
+    
+    @objc func keyboardWillHide(_ notification:NSNotification) {
+        dismiss(animated: false, completion: nil)
+    }
+}
+
+extension DetailListAddViewController: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        print(textView.contentSize.height)
+        if contentSize < textView.contentSize.height {
+            contentSize = textView.contentSize.height
+            textViewContentSizeChange(value: 20)
+        } else if contentSize > 37,
+                  contentSize > textView.contentSize.height {
+            contentSize = textView.contentSize.height
+            textViewContentSizeChange(value: -20)
+        }
+    }
+    
+    func textViewContentSizeChange(value: CGFloat) {
+        heightConstraint.constant = heightConstraint.constant + value
+    }
+}

--- a/iOS/project04/project04/Scene/DetailList/View/DetailListViewController.swift
+++ b/iOS/project04/project04/Scene/DetailList/View/DetailListViewController.swift
@@ -12,7 +12,7 @@ class DetailListViewController: UIViewController {
     @IBOutlet weak var collectionView: UICollectionView!
     private var dataSource: UICollectionViewDiffableDataSource<Detail.Section, Detail>! = nil
     var bucket: RealmBucket?
-    private var collectionViewModel: DetailListViewModelProtocol? {
+    var collectionViewModel: DetailListViewModelProtocol? {
         didSet {
             self.collectionViewModel?.listDidChange = { [weak self] _ in
                 var snapshot = NSDiffableDataSourceSnapshot<Detail.Section, Detail>()
@@ -30,7 +30,7 @@ class DetailListViewController: UIViewController {
         title = bucket?.title
         configureHierarchy()
         configureDataSource()
-        configureViewModel()
+        collectionViewModel?.listFetchAction()
     }
     
     func configureViewModel() {

--- a/iOS/project04/project04/Scene/DetailList/View/DetailListViewController.swift
+++ b/iOS/project04/project04/Scene/DetailList/View/DetailListViewController.swift
@@ -12,6 +12,7 @@ class DetailListViewController: UIViewController {
     @IBOutlet weak var collectionView: UICollectionView!
     private var dataSource: UICollectionViewDiffableDataSource<Detail.Section, Detail>! = nil
     var bucket: RealmBucket?
+    var coordinator: DetailAddCoordinator?
     var collectionViewModel: DetailListViewModelProtocol? {
         didSet {
             self.collectionViewModel?.listDidChange = { [weak self] _ in
@@ -44,7 +45,8 @@ class DetailListViewController: UIViewController {
     }
     
     @IBAction func detailAppendAction(_ sender: UIBarButtonItem) {
-        collectionViewModel?.listAddAction(Detail(title: "1", dueDate: "\(Date())"))
+        coordinator?.presentDetailListAdd(navigationController)
+//        collectionViewModel?.listAddAction(Detail(title: "1", dueDate: "\(Date())"))
     }
 }
 


### PR DESCRIPTION
## 구현의도
- detail List를 생성하는 화면을 구현했습니다.
- 의존성 주입을 위해 DetailListViewController에 주입해주는 방식으로 변경

## 기능 흐름도, 클래스 다이어그램(선택사항)
![Nov-30-2020 23-51-24](https://user-images.githubusercontent.com/31726630/100627979-0eef1980-336b-11eb-8aae-6cb4f24a14f0.gif)
![Dec-01-2020 00-04-11](https://user-images.githubusercontent.com/31726630/100627990-1282a080-336b-11eb-9e8f-fc012f50ee0a.gif)


## 리뷰요청 & 논의사항 & 궁금한점
- 아직 다 구현한건 아니고 레이아웃 틀만 잡았습니다. 화면전환은 코디네이터 패턴을 기반으로 전환했고, 이번엔 푸시방식이 아닌 present modally 방식으로 구현했습니다. 
- 추가적으로 필요한 정보는 dueDate 정도?? 아마 datePicker를 통해 구현할 것 같습니다. 