### PR TITLE
[SERVER (FIX)] 버킷 상세 전체 목록 조회 API 수정

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -18,6 +18,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
+app.use(require('express-useragent').express());
 
 models.sequelize
   .sync({ logging: false })

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1279,6 +1279,11 @@
         }
       }
     },
+    "express-useragent": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/express-useragent/-/express-useragent-1.0.15.tgz",
+      "integrity": "sha512-eq5xMiYCYwFPoekffMjvEIk+NWdlQY9Y38OsTyl13IvA728vKT+q/CSERYWzcw93HGBJcIqMIsZC5CZGARPVdg=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "debug": "~2.6.9",
     "dotenv": "^8.2.0",
     "express": "~4.16.1",
+    "express-useragent": "^1.0.15",
     "http-errors": "~1.6.3",
     "jsonwebtoken": "^8.5.1",
     "morgan": "~1.9.1",

--- a/server/routes/achieve/controller.js
+++ b/server/routes/achieve/controller.js
@@ -2,13 +2,30 @@ const { OK, CREATED, BAD_REQUEST } = require('../../config/statusCode').statusCo
 const achieveServices = require('../../services/achieve');
 
 /*
+    GET /api/achieves/:bucketNo
+    * 목표 달성 소감 조회 API
+*/
+exports.getAchieve = async (req, res, next) => {
+  try {
+    const { bucketNo } = req.params;
+    const result = await achieveServices.getAchieve(bucketNo);
+
+    res.status(CREATED).json({
+      message: '목표 달성 조회 성공',
+      data: result,
+    });
+  } catch (error) {
+    next(err);
+  }
+};
+
+/*
     POST /api/achieves
     * 목표 달성 소감 추가 API
 */
 exports.setAchieve = async (req, res, next) => {
   try {
     const data = req.body;
-    console.log(req.body);
     const result = await achieveServices.setAchieve(data);
 
     res.status(CREATED).json({
@@ -16,9 +33,7 @@ exports.setAchieve = async (req, res, next) => {
       achieveNo: result.no,
     });
   } catch (error) {
-    res.status(BAD_REQUEST).json({
-      message: '소감 추가 실패',
-    });
+    next(err);
   }
 };
 
@@ -36,8 +51,6 @@ exports.updateAchieve = async (req, res, next) => {
       message: '소감 수정 성공',
     });
   } catch (error) {
-    res.status(BAD_REQUEST).json({
-      message: '소감 수정 실패',
-    });
+    next(err);
   }
 };

--- a/server/routes/achieve/index.js
+++ b/server/routes/achieve/index.js
@@ -1,6 +1,7 @@
 const router = require('express').Router();
 const controller = require('./controller');
 
+router.get('/:bucketNo', controller.getAchieve);
 router.post('/', controller.setAchieve);
 router.put('/:no', controller.updateAchieve);
 

--- a/server/routes/detail/controller.js
+++ b/server/routes/detail/controller.js
@@ -4,13 +4,20 @@ const bucketServices = require('../../services/bucket');
 
 /*
     GET /api/details/:bucketNo
-    * 버킷 상세 목록 조회 API
+    * 버킷 상세 전체 목록 조회 API
 */
 exports.getDetails = async (req, res, next) => {
   try {
     const { bucketNo } = req.params;
-    const bucket = await bucketServices.getBucket(bucketNo);
-    const details = await detailServices.getDetails(bucketNo);
+    let bucket;
+    let details;
+    if (req.useragent.isMobile) {
+      bucket = await bucketServices.getBucket(bucketNo);
+      details = await detailServices.getDetails(bucketNo);
+    } else {
+      bucket = await bucketServices.getBucketWithAchieve(bucketNo);
+      details = await detailServices.getDetails(bucketNo);
+    }
 
     res.status(OK).json({
       message: '버킷 상세 목록 조회 성공',

--- a/server/routes/follow/controller.js
+++ b/server/routes/follow/controller.js
@@ -68,7 +68,6 @@ exports.setFollowing = async (req, res, next) => {
   try {
     const { followingNo } = req.body;
     const result = await followServices.setFollowing({ userNo, followingNo });
-    console.log(result);
     res.status(CREATED).json({
       message: '팔로우 추가 성공',
       followNo: result.no,

--- a/server/services/bucket.js
+++ b/server/services/bucket.js
@@ -53,6 +53,13 @@ exports.updateBucketTitleDesc = async (no, title, description) => {
   return result;
 };
 
+exports.getBucketWithAchieve = async (no) => {
+  const result = await db.selectBucketWithAchieve(no);
+  const temp = { ...result, achieveComment: result['achieve.description'] };
+  delete temp['achieve.description'];
+  return temp;
+};
+
 exports.getBucket = async (no) => {
   const result = await db.selectBucket(no);
   return result;

--- a/server/services/db/achieve.js
+++ b/server/services/db/achieve.js
@@ -1,15 +1,6 @@
 const { Achieve } = require('../../models');
 
-exports.selectAchieve = async (no) => {
-  const result = await Achieve.findOne({
-    where: { no },
-    raw: true,
-  });
-
-  return result;
-};
-
-exports.selectBucketAchieve = async (bucketNo) => {
+exports.selectAchieve = async (bucketNo) => {
   const result = await Achieve.findOne({
     where: { bucketNo },
     raw: true,

--- a/server/services/db/bucket.js
+++ b/server/services/db/bucket.js
@@ -1,5 +1,5 @@
 const { Op } = require('sequelize');
-const { Bucket, Detail, User } = require('../../models');
+const { Bucket, User, Achieve } = require('../../models');
 
 exports.getPresets = async (keyword) => {
   const results = await Bucket.findAll({
@@ -52,6 +52,21 @@ exports.updateBucketTitleDesc = async (no, title, description) => {
 
 exports.selectBucket = async (no) => {
   const results = await Bucket.findOne({ raw: true, where: { no } });
+
+  return results;
+};
+
+exports.selectBucketWithAchieve = async (no) => {
+  const results = await Bucket.findOne({
+    raw: true,
+    where: { no },
+    include: [
+      {
+        model: Achieve,
+        attributes: ['description'],
+      },
+    ],
+  });
 
   return results;
 };

--- a/server/services/detail.js
+++ b/server/services/detail.js
@@ -1,5 +1,4 @@
 const db = require('./db/detail');
-const adb = require('./db/achieve');
 
 exports.bulkCreate = async (details) => {
   const newBucket = await db.bulkCreate(details);
@@ -20,7 +19,6 @@ const initialDetails = () => {
   const result = {};
   result.openDetails = [];
   result.achieveDetails = [];
-  result.achieveComment = null;
   return result;
 };
 
@@ -36,11 +34,7 @@ const detailsByStatus = (details) => {
 
 exports.getDetails = async (bucketNo) => {
   const details = await db.selectDetails(bucketNo);
-  const achieve = await adb.selectBucketAchieve(bucketNo);
   const result = detailsByStatus(details);
-  if (achieve) {
-    result.achieveComment = achieve.description;
-  }
   return result;
 };
 


### PR DESCRIPTION
## 구현의도
- express-useragent로 iOS와 web API 분리
  - 버킷 상세 목록 조회 API 에서 소감 조회를 분리
  - 목표 달성 소감 조회 API 구현

## API 명세
### 버킷 상세 전체 목록 조회 API (iOS) 

Request
```
GET /api/details/1
```

Response
```
{
    "message": "버킷 상세 목록 조회 성공",
    "data": {
        "bucket": {
            "no": 1,
            "title": "목표1",
            "status": "O",
            "description": "목표1 설명",
            "refCount": 0,
            "createdAt": "2020-11-26 21:10:27",
            "updatedAt": "2020-12-05 17:49:32",
            "userNo": 1
        },
        "details": {
            "openDetails": [...],
            "achieveDetails": [...],
        }
    }
}
```

### 버킷 상세 전체 목록 조회 API (web) 

Request
```
GET /api/details/1
```

Response
```
{
    "message": "버킷 상세 목록 조회 성공",
    "data": {
        "bucket": {
            "no": 1,
            "title": "목표1",
            "status": "O",
            "description": "목표1 설명",
            "refCount": 0,
            "createdAt": "2020-11-26 21:10:27",
            "updatedAt": "2020-12-05 17:49:32",
            "userNo": 1,
            "achieveComment": "",
        },
        "details": {
            "openDetails": [...],
            "achieveDetails": [...],
        }
    }
}
```

### 목표 달성 소감 조회 API (iOS) 

Request
```
GET /api/achieves/1
```

Response
```
{
    "message": "목표 달성 조회 성공",
    "data": {
        "no": 14,
        "description": "...",
        "createdAt": "2020-12-04 13:34:58",
        "updatedAt": "2020-12-04 13:34:58",
        "deletedAt": null,
        "bucketNo": 2
    }
}
```