### PR TITLE
[iOS #107] 소감 생성 화면 구현

### DIFF
--- a/iOS/project04/project04.xcodeproj/project.pbxproj
+++ b/iOS/project04/project04.xcodeproj/project.pbxproj
@@ -31,6 +31,14 @@
 		C16019BB25792DCC00506430 /* PieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16019BA25792DCC00506430 /* PieView.swift */; };
 		C16019C025792FEE00506430 /* DetailSectionGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16019BE25792FEE00506430 /* DetailSectionGraphView.swift */; };
 		C16019C125792FEE00506430 /* DetailSectionGraphView.xib in Resources */ = {isa = PBXBuildFile; fileRef = C16019BF25792FEE00506430 /* DetailSectionGraphView.xib */; };
+		C1604D0D257DFC450019E6E2 /* RealmImpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1604D0C257DFC450019E6E2 /* RealmImpression.swift */; };
+		C1604D11257DFEB30019E6E2 /* ImpressionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1604D10257DFEB30019E6E2 /* ImpressionUseCase.swift */; };
+		C1604D15257E0E3C0019E6E2 /* ImpressionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1604D14257E0E3C0019E6E2 /* ImpressionRepository.swift */; };
+		C1604D19257E0EF90019E6E2 /* ImpressionLocalAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1604D18257E0EF90019E6E2 /* ImpressionLocalAgent.swift */; };
+		C1604D1D257E0F050019E6E2 /* ImpressionAPIAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1604D1C257E0F050019E6E2 /* ImpressionAPIAgent.swift */; };
+		C160C4D8257DC84100578BE3 /* ImpressionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C160C4D7257DC84100578BE3 /* ImpressionViewController.swift */; };
+		C160C4DE257DC85D00578BE3 /* Impression.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C160C4DD257DC85D00578BE3 /* Impression.storyboard */; };
+		C160C4E2257DCC6700578BE3 /* ImpressionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C160C4E1257DCC6700578BE3 /* ImpressionViewModel.swift */; };
 		C160DBA925775FA400290EAE /* DetailSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C160DBA725775FA400290EAE /* DetailSectionHeaderView.swift */; };
 		C160DBAA25775FA400290EAE /* DetailSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = C160DBA825775FA400290EAE /* DetailSectionHeaderView.xib */; };
 		C160DBB025776DB800290EAE /* DetailSectionImpressionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C160DBAE25776DB800290EAE /* DetailSectionImpressionHeaderView.swift */; };
@@ -52,7 +60,7 @@
 		C1754F07256E4AC00037C805 /* ListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1754F06256E4AC00037C805 /* ListUseCase.swift */; };
 		C175AA7825752C57009D8103 /* DetailListAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C175AA7725752C57009D8103 /* DetailListAddViewController.swift */; };
 		C175AA7C25752C7D009D8103 /* DetailListAdd.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C175AA7B25752C7D009D8103 /* DetailListAdd.storyboard */; };
-		C175AA8025752F72009D8103 /* DetailAddCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C175AA7F25752F72009D8103 /* DetailAddCoordinator.swift */; };
+		C175AA8025752F72009D8103 /* DetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C175AA7F25752F72009D8103 /* DetailCoordinator.swift */; };
 		C175D190256CC028001144F0 /* DetailListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C175D18F256CC028001144F0 /* DetailListUseCase.swift */; };
 		C175D194256CC2EC001144F0 /* DetailAPIAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C175D193256CC2EC001144F0 /* DetailAPIAgent.swift */; };
 		C175D197256CC31C001144F0 /* DetailLocalAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C175D196256CC31C001144F0 /* DetailLocalAgent.swift */; };
@@ -107,6 +115,14 @@
 		C16019BA25792DCC00506430 /* PieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieView.swift; sourceTree = "<group>"; };
 		C16019BE25792FEE00506430 /* DetailSectionGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSectionGraphView.swift; sourceTree = "<group>"; };
 		C16019BF25792FEE00506430 /* DetailSectionGraphView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DetailSectionGraphView.xib; sourceTree = "<group>"; };
+		C1604D0C257DFC450019E6E2 /* RealmImpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmImpression.swift; sourceTree = "<group>"; };
+		C1604D10257DFEB30019E6E2 /* ImpressionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionUseCase.swift; sourceTree = "<group>"; };
+		C1604D14257E0E3C0019E6E2 /* ImpressionRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionRepository.swift; sourceTree = "<group>"; };
+		C1604D18257E0EF90019E6E2 /* ImpressionLocalAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionLocalAgent.swift; sourceTree = "<group>"; };
+		C1604D1C257E0F050019E6E2 /* ImpressionAPIAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionAPIAgent.swift; sourceTree = "<group>"; };
+		C160C4D7257DC84100578BE3 /* ImpressionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionViewController.swift; sourceTree = "<group>"; };
+		C160C4DD257DC85D00578BE3 /* Impression.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Impression.storyboard; sourceTree = "<group>"; };
+		C160C4E1257DCC6700578BE3 /* ImpressionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionViewModel.swift; sourceTree = "<group>"; };
 		C160DBA725775FA400290EAE /* DetailSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSectionHeaderView.swift; sourceTree = "<group>"; };
 		C160DBA825775FA400290EAE /* DetailSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DetailSectionHeaderView.xib; sourceTree = "<group>"; };
 		C160DBAE25776DB800290EAE /* DetailSectionImpressionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSectionImpressionHeaderView.swift; sourceTree = "<group>"; };
@@ -130,7 +146,7 @@
 		C1754F06256E4AC00037C805 /* ListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListUseCase.swift; sourceTree = "<group>"; };
 		C175AA7725752C57009D8103 /* DetailListAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailListAddViewController.swift; sourceTree = "<group>"; };
 		C175AA7B25752C7D009D8103 /* DetailListAdd.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = DetailListAdd.storyboard; sourceTree = "<group>"; };
-		C175AA7F25752F72009D8103 /* DetailAddCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailAddCoordinator.swift; sourceTree = "<group>"; };
+		C175AA7F25752F72009D8103 /* DetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCoordinator.swift; sourceTree = "<group>"; };
 		C175D18F256CC028001144F0 /* DetailListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailListUseCase.swift; sourceTree = "<group>"; };
 		C175D193256CC2EC001144F0 /* DetailAPIAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailAPIAgent.swift; sourceTree = "<group>"; };
 		C175D196256CC31C001144F0 /* DetailLocalAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailLocalAgent.swift; sourceTree = "<group>"; };
@@ -295,6 +311,52 @@
 			path = Repository;
 			sourceTree = "<group>";
 		};
+		C160C4D2257DC79700578BE3 /* Impression */ = {
+			isa = PBXGroup;
+			children = (
+				C160C4D3257DC7B000578BE3 /* ViewModel */,
+				C160C4D4257DC7BA00578BE3 /* UseCase */,
+				C160C4D5257DC7C300578BE3 /* Repository */,
+				C160C4D6257DC7CC00578BE3 /* View */,
+			);
+			path = Impression;
+			sourceTree = "<group>";
+		};
+		C160C4D3257DC7B000578BE3 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				C160C4E1257DCC6700578BE3 /* ImpressionViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		C160C4D4257DC7BA00578BE3 /* UseCase */ = {
+			isa = PBXGroup;
+			children = (
+				C1604D10257DFEB30019E6E2 /* ImpressionUseCase.swift */,
+			);
+			path = UseCase;
+			sourceTree = "<group>";
+		};
+		C160C4D5257DC7C300578BE3 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				C1604D14257E0E3C0019E6E2 /* ImpressionRepository.swift */,
+				C1604D18257E0EF90019E6E2 /* ImpressionLocalAgent.swift */,
+				C1604D1C257E0F050019E6E2 /* ImpressionAPIAgent.swift */,
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
+		C160C4D6257DC7CC00578BE3 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				C160C4D7257DC84100578BE3 /* ImpressionViewController.swift */,
+				C160C4DD257DC85D00578BE3 /* Impression.storyboard */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		C160DBAD25776C0000290EAE /* SectionHeaderView */ = {
 			isa = PBXGroup;
 			children = (
@@ -418,6 +480,7 @@
 			children = (
 				C175D19A256CCF3C001144F0 /* RealmDetailList.swift */,
 				82A7291E256F4BCB00BD5797 /* RealmBucket.swift */,
+				C1604D0C257DFC450019E6E2 /* RealmImpression.swift */,
 			);
 			path = RealmObject;
 			sourceTree = "<group>";
@@ -442,6 +505,7 @@
 		C1900D77256B83970071E8C7 /* Scene */ = {
 			isa = PBXGroup;
 			children = (
+				C160C4D2257DC79700578BE3 /* Impression */,
 				C1900D7C256B85D50071E8C7 /* DetailList */,
 				C1900D78256B84840071E8C7 /* BucketList */,
 				8261DBA225789D1F0027F6F8 /* BucketListSearch */,
@@ -510,7 +574,7 @@
 			children = (
 				C1E6C4162574D45900BD4B4B /* MainTabBarController.swift */,
 				C1E6C41A2574D4BE00BD4B4B /* BucketCoordinator.swift */,
-				C175AA7F25752F72009D8103 /* DetailAddCoordinator.swift */,
+				C175AA7F25752F72009D8103 /* DetailCoordinator.swift */,
 				C1E6C41E2574E83200BD4B4B /* NavigationCoordinator.swift */,
 				8261DBAE25789EC20027F6F8 /* BucketListSearchCoordinator.swift */,
 			);
@@ -601,6 +665,7 @@
 			files = (
 				C11AC460256B7F8B00E45667 /* .swiftlint.yml in Resources */,
 				C1655CA1256B7ED30067E3C5 /* LaunchScreen.storyboard in Resources */,
+				C160C4DE257DC85D00578BE3 /* Impression.storyboard in Resources */,
 				8261DB7C2575F89F0027F6F8 /* BucketListAdd.storyboard in Resources */,
 				C1E6C40E2574D27900BD4B4B /* BucketList.storyboard in Resources */,
 				C160DBB125776DB800290EAE /* DetailSectionImpressionHeaderView.xib in Resources */,
@@ -672,7 +737,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				C1655C99256B7ED10067E3C5 /* BucketListViewController.swift in Sources */,
-				C175AA8025752F72009D8103 /* DetailAddCoordinator.swift in Sources */,
+				C160C4E2257DCC6700578BE3 /* ImpressionViewModel.swift in Sources */,
+				C175AA8025752F72009D8103 /* DetailCoordinator.swift in Sources */,
 				C175AA7825752C57009D8103 /* DetailListAddViewController.swift in Sources */,
 				82A72917256F43E100BD5797 /* BucketLocalAgent.swift in Sources */,
 				82F12FD82579B59C0079DB71 /* BucketListSearchRepository.swift in Sources */,
@@ -682,7 +748,10 @@
 				C1BFAD0B25761BF300BDEF93 /* RoundButton.swift in Sources */,
 				C1754EF1256E1A570037C805 /* NetworkError.swift in Sources */,
 				82A7291B256F448100BD5797 /* BucketAPIAgent.swift in Sources */,
+				C1604D0D257DFC450019E6E2 /* RealmImpression.swift in Sources */,
+				C1604D1D257E0F050019E6E2 /* ImpressionAPIAgent.swift in Sources */,
 				8261DBAF25789EC20027F6F8 /* BucketListSearchCoordinator.swift in Sources */,
+				C1604D19257E0EF90019E6E2 /* ImpressionLocalAgent.swift in Sources */,
 				C1E6C41B2574D4BE00BD4B4B /* BucketCoordinator.swift in Sources */,
 				C175D190256CC028001144F0 /* DetailListUseCase.swift in Sources */,
 				8215F5242579A81800DDCD09 /* BucketListSearchViewModel.swift in Sources */,
@@ -691,6 +760,7 @@
 				C16019BB25792DCC00506430 /* PieView.swift in Sources */,
 				C164DF962578AAD20046B902 /* DetailSectionHeaderTodoView.swift in Sources */,
 				C175D197256CC31C001144F0 /* DetailLocalAgent.swift in Sources */,
+				C1604D15257E0E3C0019E6E2 /* ImpressionRepository.swift in Sources */,
 				C1754EE3256E17F20037C805 /* LocalService.swift in Sources */,
 				C160DBA925775FA400290EAE /* DetailSectionHeaderView.swift in Sources */,
 				8259AAFD256B9D49006698FC /* BucketListViewModel.swift in Sources */,
@@ -704,12 +774,14 @@
 				C1E6C41F2574E83200BD4B4B /* NavigationCoordinator.swift in Sources */,
 				C160DBB025776DB800290EAE /* DetailSectionImpressionHeaderView.swift in Sources */,
 				C16019C025792FEE00506430 /* DetailSectionGraphView.swift in Sources */,
+				C160C4D8257DC84100578BE3 /* ImpressionViewController.swift in Sources */,
 				C1754EEC256E197C0037C805 /* NetworkService.swift in Sources */,
 				C1754EF5256E1B8B0037C805 /* HTTPMethod.swift in Sources */,
 				C1BFAD10257631F400BDEF93 /* DefaultAlertViewController.swift in Sources */,
 				C1BFAD162576340800BDEF93 /* extension+UIDatePicker.swift in Sources */,
 				C1900D7E256B85ED0071E8C7 /* DetailListViewController.swift in Sources */,
 				C1754EDC256E13650037C805 /* DetailRepository.swift in Sources */,
+				C1604D11257DFEB30019E6E2 /* ImpressionUseCase.swift in Sources */,
 				8261DB8A25761A420027F6F8 /* BucketListAddViewModel.swift in Sources */,
 				82A7290E256F41DD00BD5797 /* BucketListUseCase.swift in Sources */,
 				C16BEFB52579CF2000108265 /* extension+UIColor.swift in Sources */,

--- a/iOS/project04/project04/Coordinator/BucketCoordinator.swift
+++ b/iOS/project04/project04/Coordinator/BucketCoordinator.swift
@@ -42,14 +42,16 @@ final class BucketCoordinator: NavigationCoordinator {
 extension BucketCoordinator: DetailListPushCoordinator {
     func pushToDetailList(bucket: RealmBucket?, index: Int, delegate: BucketListObserverDelegate) {
         let viewModel = configureDetailListViewModel(bucket: bucket)
-        let coordinator = DetailAddCoordinator(navigationController)
+        let impressionViewModel = configureImpressionViewModel(bucketNo: bucket?.id ?? 0)
+        let coordinator = DetailCoordinator(navigationController)
         let viewController = UIStoryboard(name: "DetailList", bundle: nil).instantiateViewController(identifier: "DetailListViewController", creator: { coder in
             return DetailListViewController(coder: coder,
                                             bucket: bucket,
                                             viewModel: viewModel,
                                             coordinator: coordinator,
                                             index: index,
-                                            delegate: delegate)
+                                            delegate: delegate,
+                                            impressionViewModel: impressionViewModel)
         })
         navigationController.pushViewController(viewController, animated: true)
     }
@@ -60,6 +62,14 @@ extension BucketCoordinator: DetailListPushCoordinator {
         let repository = DetailRepository(network: networkAgent, local: localAgent)
         let usecase = DetailListUseCase(repository: repository)
         return DetailListViewModel(usecase: usecase)
+    }
+    
+    private func configureImpressionViewModel(bucketNo: Int) -> ImpressionViewModel {
+        let networkAgent = ImpressionAPIAgent()
+        let localAgent = ImpressionLocalAgent(bucketNo: bucketNo)
+        let repository = ImpressionRepository(local: localAgent, network: networkAgent)
+        let usecase = ImpressionUseCase(repository: repository)
+        return ImpressionViewModel(usecase: usecase)
     }
 }
 

--- a/iOS/project04/project04/Coordinator/DetailCoordinator.swift
+++ b/iOS/project04/project04/Coordinator/DetailCoordinator.swift
@@ -4,11 +4,10 @@
 //
 //  Created by 남기범 on 2020/11/30.
 //
-
 import Foundation
 import UIKit
 
-class DetailAddCoordinator: NavigationCoordinator {
+class DetailCoordinator: NavigationCoordinator {
     var navigationController: UINavigationController
     
     required init(_ navigationController: UINavigationController) {
@@ -21,6 +20,13 @@ class DetailAddCoordinator: NavigationCoordinator {
                                                viewModel: viewModel,
                                                detail: detail,
                                                index: index)
+        })
+        navigationController?.present(viewController, animated: false)
+    }
+    
+    func presentImpression(_ navigationController: UINavigationController?, viewModel: ImpressionDelegate) {
+        let viewController = UIStoryboard(name: "Impression", bundle: nil).instantiateViewController(identifier: "ImpressionViewController", creator: { coder in
+            return ImpressionViewController(coder: coder, viewModel: viewModel)
         })
         navigationController?.present(viewController, animated: false)
     }

--- a/iOS/project04/project04/Info.plist
+++ b/iOS/project04/project04/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>올해는꼭</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/iOS/project04/project04/Model/RealmObject/RealmImpression.swift
+++ b/iOS/project04/project04/Model/RealmObject/RealmImpression.swift
@@ -1,0 +1,24 @@
+//
+//  RealmImpression.swift
+//  project04
+//
+//  Created by 남기범 on 2020/12/07.
+//
+
+import Foundation
+import RealmSwift
+
+class RealmImpression: Object, Codable {
+    @objc dynamic var text: String = ""
+    @objc dynamic var bucketNo: Int = 0
+    
+    private enum CodingKeys: String, CodingKey {
+        case text = "description"
+    }
+    
+    required convenience init(from decoder: Decoder) throws {
+        self.init()
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        text = try values.decode(String.self, forKey: .text)
+    }
+}

--- a/iOS/project04/project04/Scene/DetailList/View/SectionHeaderView/DetailSectionImpressionHeaderView.swift
+++ b/iOS/project04/project04/Scene/DetailList/View/SectionHeaderView/DetailSectionImpressionHeaderView.swift
@@ -8,10 +8,15 @@
 import UIKit
 
 class DetailSectionImpressionHeaderView: UICollectionReusableView {
-
+    @IBOutlet weak var impressionLabel: UILabel!
+    var editHandler: (() -> ())?
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
     }
     
+    @IBAction func impressionEditAction(_ sender: UIButton) {
+        editHandler?()
+    }
 }

--- a/iOS/project04/project04/Scene/DetailList/View/SectionHeaderView/DetailSectionImpressionHeaderView.xib
+++ b/iOS/project04/project04/Scene/DetailList/View/SectionHeaderView/DetailSectionImpressionHeaderView.xib
@@ -36,6 +36,9 @@
                             <state key="normal" title="•••">
                                 <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </state>
+                            <connections>
+                                <action selector="impressionEditAction:" destination="U6b-Vx-4bR" eventType="touchUpInside" id="Q9s-9z-GMK"/>
+                            </connections>
                         </button>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.circle.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="pxz-fl-gXy">
                             <rect key="frame" x="20" y="8.5" width="30" height="29"/>
@@ -87,6 +90,9 @@
                 <constraint firstItem="UEY-sd-6gW" firstAttribute="trailing" secondItem="VXr-Tz-HHm" secondAttribute="trailing" id="nMB-u2-S7Y"/>
                 <constraint firstItem="UEY-sd-6gW" firstAttribute="top" secondItem="uYr-iq-rgg" secondAttribute="bottom" constant="10" id="oGf-yY-lK0"/>
             </constraints>
+            <connections>
+                <outlet property="impressionLabel" destination="utd-Mm-I8f" id="msu-WP-bVp"/>
+            </connections>
             <point key="canvasLocation" x="241.30434782608697" y="171.42857142857142"/>
         </collectionReusableView>
     </objects>

--- a/iOS/project04/project04/Scene/Impression/Repository/ImpressionAPIAgent.swift
+++ b/iOS/project04/project04/Scene/Impression/Repository/ImpressionAPIAgent.swift
@@ -1,0 +1,21 @@
+//
+//  ImpressionAPIAgent.swift
+//  project04
+//
+//  Created by 남기범 on 2020/12/07.
+//
+
+import Foundation
+
+class ImpressionAPIAgent: NetworkService {
+    typealias Item = RealmImpression
+    enum RequestURL {
+        static let fetch = "https://~~"
+        static let save = "https://~~"
+        static let revise = "https://~~"
+    }
+    
+    func request(from urlString: String, method: HTTPMethod, body: RealmImpression?, completion: @escaping (Result<Data, NetworkError>) -> Void) {
+        completion(.failure(.URLError))
+    }
+}

--- a/iOS/project04/project04/Scene/Impression/Repository/ImpressionLocalAgent.swift
+++ b/iOS/project04/project04/Scene/Impression/Repository/ImpressionLocalAgent.swift
@@ -1,0 +1,59 @@
+//
+//  ImpressionLocalAgent.swift
+//  project04
+//
+//  Created by 남기범 on 2020/12/07.
+//
+
+import Foundation
+import RealmSwift
+
+protocol ImpressionLocalAgentProtocol {
+    func fetch(bucketNo: Int) -> RealmImpression?
+    func save(text: String)
+    func edit(element: RealmImpression, text: String)
+}
+
+class ImpressionLocalAgent {
+    private var bucketNo: Int
+    
+    init(bucketNo: Int) {
+        self.bucketNo = bucketNo
+    }
+    
+    func fetch(bucketNo: Int) -> RealmImpression? {
+        do {
+            let realm = try Realm()
+            let object = realm.objects(RealmImpression.self).filter("#bucketNo == \(bucketNo)").first
+            return object
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+    
+    func save(text: String) {
+        do {
+            let realm = try Realm()
+            
+            try realm.write {
+                let object = realm.objects(RealmImpression.self).filter("#bucketNo == \(bucketNo)")
+                realm.delete(object)
+                let impression = RealmImpression(value: [text, bucketNo])
+                realm.add(impression)
+            }
+        } catch {
+            print(error)
+        }
+    }
+    
+    func edit(element: RealmImpression?, text: String) {
+        do {
+            try Realm().write {
+                element?.text = text
+            }
+        } catch {
+            print(error)
+        }
+    }
+}

--- a/iOS/project04/project04/Scene/Impression/Repository/ImpressionRepository.swift
+++ b/iOS/project04/project04/Scene/Impression/Repository/ImpressionRepository.swift
@@ -1,0 +1,72 @@
+//
+//  ImpressionRepository.swift
+//  project04
+//
+//  Created by 남기범 on 2020/12/07.
+//
+
+import Foundation
+
+
+//protocol ImpressionUseCaseProtocol {
+//    func fetch(bucketNo: Int)
+//    func save(text: String)
+//    func edit(text: String)
+//}
+protocol ImpressionRepositoryProtocol {
+    func fetchImpression(bucketNo: Int, completion: @escaping (RealmImpression?) -> Void)
+    func saveImpression(text: String)
+    func editImpression(element: RealmImpression?, text: String)
+}
+
+class ImpressionRepository: ImpressionRepositoryProtocol {
+    private var local: ImpressionLocalAgent
+    private var network: ImpressionAPIAgent
+    
+    init(local: ImpressionLocalAgent, network: ImpressionAPIAgent) {
+        self.local = local
+        self.network = network
+    }
+    
+    func fetchImpression(bucketNo: Int, completion: @escaping (RealmImpression?) -> Void) {
+        network.request(from: ImpressionAPIAgent.RequestURL.fetch,
+                        method: .GET,
+                        body: nil,
+                        completion: { [weak self] result in
+                            switch result {
+                            case .success(_):
+                                break
+                            case .failure(_):
+                                completion(self?.local.fetch(bucketNo: bucketNo))
+                            }
+        })
+    }
+    
+    func saveImpression(text: String) {
+        network.request(from: ImpressionAPIAgent.RequestURL.save,
+                        method: .GET,
+                        body: nil,
+                        completion: { [weak self] result in
+                            switch result {
+                            case .success(_):
+                                break
+                            case .failure(_):
+                                self?.local.save(text: text)
+                            }
+        })
+    }
+    
+    func editImpression(element: RealmImpression?, text: String) {
+        network.request(from: ImpressionAPIAgent.RequestURL.revise,
+                        method: .GET,
+                        body: nil,
+                        completion: { [weak self] result in
+                            switch result {
+                            case .success(_):
+                                break
+                            case .failure(_):
+                                self?.local.edit(element: element, text: text)
+                            }
+        })
+    }
+}

--- a/iOS/project04/project04/Scene/Impression/UseCase/ImpressionUseCase.swift
+++ b/iOS/project04/project04/Scene/Impression/UseCase/ImpressionUseCase.swift
@@ -1,0 +1,36 @@
+//
+//  ImpressionUseCase.swift
+//  project04
+//
+//  Created by 남기범 on 2020/12/07.
+//
+
+import Foundation
+
+protocol ImpressionUseCaseProtocol {
+    func fetch(bucketNo: Int, completion: @escaping (RealmImpression?) -> Void)
+    func save(text: String)
+    func edit(element: RealmImpression?, text: String)
+}
+
+class ImpressionUseCase: ImpressionUseCaseProtocol {
+    var repository: ImpressionRepositoryProtocol
+    
+    init(repository: ImpressionRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    func fetch(bucketNo: Int, completion: @escaping (RealmImpression?) -> Void) {
+        repository.fetchImpression(bucketNo: bucketNo, completion: { impression in
+            completion(impression)
+        })
+    }
+    
+    func save(text: String) {
+        repository.saveImpression(text: text)
+    }
+    
+    func edit(element: RealmImpression?, text: String) {
+        repository.editImpression(element: element, text: text)
+    }
+}

--- a/iOS/project04/project04/Scene/Impression/View/Impression.storyboard
+++ b/iOS/project04/project04/Scene/Impression/View/Impression.storyboard
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="yor-tS-Mit">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Impression View Controller-->
+        <scene sceneID="4Me-r2-v4h">
+            <objects>
+                <viewController storyboardIdentifier="ImpressionViewController" id="yor-tS-Mit" customClass="ImpressionViewController" customModule="project04" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="C8W-CG-9XO">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="소감 작성" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lsG-iW-DO8">
+                                <rect key="frame" x="20" y="54" width="74" height="24"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9lg-wQ-JtX">
+                                <rect key="frame" x="359" y="49" width="35" height="36"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                <state key="normal" title="완료"/>
+                                <connections>
+                                    <action selector="impressionSaveAction:" destination="yor-tS-Mit" eventType="touchUpInside" id="aLU-Br-hqN"/>
+                                </connections>
+                            </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="0ZJ-8Q-SJ8">
+                                <rect key="frame" x="20" y="86" width="374" height="776"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="FVu-ou-hZr"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="0ZJ-8Q-SJ8" firstAttribute="leading" secondItem="FVu-ou-hZr" secondAttribute="leading" constant="20" id="Cdd-qV-1zY"/>
+                            <constraint firstItem="FVu-ou-hZr" firstAttribute="trailing" secondItem="9lg-wQ-JtX" secondAttribute="trailing" constant="20" id="I9b-Wg-cri"/>
+                            <constraint firstItem="lsG-iW-DO8" firstAttribute="leading" secondItem="FVu-ou-hZr" secondAttribute="leading" constant="20" id="TpD-X5-QFX"/>
+                            <constraint firstItem="0ZJ-8Q-SJ8" firstAttribute="top" secondItem="lsG-iW-DO8" secondAttribute="bottom" constant="8" id="UKo-6J-qFd"/>
+                            <constraint firstItem="0ZJ-8Q-SJ8" firstAttribute="bottom" secondItem="FVu-ou-hZr" secondAttribute="bottom" id="aaL-uR-D7G"/>
+                            <constraint firstItem="FVu-ou-hZr" firstAttribute="trailing" secondItem="0ZJ-8Q-SJ8" secondAttribute="trailing" constant="20" id="nAa-lo-eTM"/>
+                            <constraint firstItem="lsG-iW-DO8" firstAttribute="top" secondItem="FVu-ou-hZr" secondAttribute="top" constant="10" id="ohN-fH-aNi"/>
+                            <constraint firstItem="9lg-wQ-JtX" firstAttribute="top" secondItem="FVu-ou-hZr" secondAttribute="top" constant="5" id="xZt-4f-3UD"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="impressionTextView" destination="0ZJ-8Q-SJ8" id="dPW-7d-pA7"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yFs-91-6YJ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="147.82608695652175" y="146.65178571428569"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/iOS/project04/project04/Scene/Impression/View/ImpressionViewController.swift
+++ b/iOS/project04/project04/Scene/Impression/View/ImpressionViewController.swift
@@ -1,0 +1,66 @@
+//
+//  ImpressionViewController.swift
+//  project04
+//
+//  Created by 남기범 on 2020/12/07.
+//
+
+import UIKit
+
+class ImpressionViewController: UIViewController {
+    @IBOutlet weak var impressionTextView: UITextView!
+    var delegate: ImpressionDelegate
+    var isEdited: Bool = false
+    
+    init?(coder: NSCoder, viewModel: ImpressionDelegate) {
+        self.delegate = viewModel
+        super.init(coder: coder)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        impressionTextView.text = delegate.impressionViewModel.impressionText
+        isEdited = (impressionTextView.text != "")
+        impressionTextView.delegate = self
+        impressionTextView.becomeFirstResponder()
+    }
+    
+    @IBAction func impressionSaveAction(_ sender: UIButton) {
+        if impressionTextView.text == "" {
+            let alert = defaultAlertViewController(title: "소감 입력", message: "소감을 입력하지 않았습니다.")
+            present(alert, animated: true, completion: nil)
+            return
+        }
+        
+        if isEdited {
+            delegate.impressionViewModel.impressionEdit(text: impressionTextView.text)
+        } else {
+            delegate.impressionViewModel.impressionSave(text: impressionTextView.text)
+        }
+        
+        dismiss(animated: true, completion: nil)
+    }
+}
+extension ImpressionViewController: UITextViewDelegate {
+    func configureTextViewPlaceholder() {
+        impressionTextView.text = "소감을 입력해주세요."
+        impressionTextView.textColor = .secondaryLabel
+    }
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.textColor == .secondaryLabel {
+            textView.textColor = .label
+            textView.text = nil
+        }
+    }
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            configureTextViewPlaceholder()
+        }
+    }
+}

--- a/iOS/project04/project04/Scene/Impression/ViewModel/ImpressionViewModel.swift
+++ b/iOS/project04/project04/Scene/Impression/ViewModel/ImpressionViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  ImpressionViewModel.swift
+//  project04
+//
+//  Created by 남기범 on 2020/12/07.
+//
+
+import Foundation
+
+protocol ImpressionViewModelProtocol {
+    var realmImpression: RealmImpression? { get set }
+    var impressionText: String { get set }
+    var textChange: ((ImpressionViewModelProtocol)->())? { get set }
+    func impressionFetch(bucketNo: Int)
+    func impressionSave(text: String)
+    func impressionEdit(text: String)
+}
+
+class ImpressionViewModel: ImpressionViewModelProtocol {
+    var realmImpression: RealmImpression?
+    
+    var impressionText: String = "" {
+        didSet {
+            self.textChange?(self)
+        }
+    }
+    
+    var usecase: ImpressionUseCaseProtocol
+    var textChange: ((ImpressionViewModelProtocol) -> ())?
+    
+    required init(usecase: ImpressionUseCaseProtocol) {
+        self.usecase = usecase
+    }
+    
+    func impressionFetch(bucketNo: Int) {
+        usecase.fetch(bucketNo: bucketNo, completion: { [weak self] impression in
+            self?.realmImpression = impression
+            self?.impressionText = impression?.text ?? ""
+        })
+    }
+    
+    func impressionSave(text: String) {
+        usecase.save(text: text)
+        impressionText = text
+    }
+    
+    func impressionEdit(text: String) {
+        usecase.edit(element: self.realmImpression, text: text)
+        impressionText = text
+    }
+}


### PR DESCRIPTION
## 구현의도
- 소감 생성화면을 구현하고, 소감을 detail에 띄워줍니다. 소감은 초기 작성 이후에도 수정이 가능하며 초기에 작성을 안했더라도 나중에 입력할 수 있습니다.

## 구현화면
![Dec-07-2020 22-55-32](https://user-images.githubusercontent.com/31726630/101359299-68ad9180-38df-11eb-8a81-ff3da21902b4.gif)

## 논의사항
- animate를 false를 줘서 그런지 소감 생성 화면이 부자연스럽게 뜨네요.. 이 부분은 추후에 수정하겠습니다.
- 구현화면은 소감을 입력하지 않았을 때에대한 예시입니다.