### PR TITLE
[SERVER #128] 피드페이지 API 구현

### DIFF
--- a/server/models/feed.js
+++ b/server/models/feed.js
@@ -1,0 +1,23 @@
+module.exports = function (sequelize, DataTypes) {
+  return sequelize.define(
+    'feed',
+    {
+      no: {
+        autoIncrement: true,
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+      },
+      content: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+      },
+    },
+    {
+      tableName: 'feed',
+      timestamps: true,
+      paranoid: true,
+      underscored: true,
+    }
+  );
+};

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -13,12 +13,21 @@ db.Bucket = require('./bucket')(sequelize, Sequelize);
 db.Detail = require('./detail')(sequelize, Sequelize);
 db.Achieve = require('./achieve')(sequelize, Sequelize);
 db.Follow = require('./follow')(sequelize, Sequelize);
+db.Feed = require('./feed')(sequelize, Sequelize);
 
-// 관계정의 users : bucket = 1 : N
+// 관계정의 user : bucket = 1 : N
 db.User.hasMany(db.Bucket, {
   foreignKey: { allowNull: false },
 });
 db.Bucket.belongsTo(db.User, {
+  foreignKey: { allowNull: false },
+});
+
+// 관계정의 user : feed = 1 : N
+db.User.hasMany(db.Feed, {
+  foreignKey: { allowNull: false },
+});
+db.Feed.belongsTo(db.User, {
   foreignKey: { allowNull: false },
 });
 

--- a/server/routes/achieve/controller.js
+++ b/server/routes/achieve/controller.js
@@ -27,6 +27,7 @@ exports.setAchieve = async (req, res, next) => {
   try {
     const data = req.body;
     const result = await achieveServices.setAchieve(data);
+    feedServices.addFeed(1, '달성소감을 추가했습니다.');
 
     res.status(CREATED).json({
       message: '소감 추가 성공',
@@ -47,6 +48,8 @@ exports.updateAchieve = async (req, res, next) => {
 
   try {
     await achieveServices.updateAchieve({ no, description });
+    feedServices.addFeed(1, '달성소감을 수정했습니다.');
+
     res.status(OK).json({
       message: '소감 수정 성공',
     });

--- a/server/routes/bucket/controller.js
+++ b/server/routes/bucket/controller.js
@@ -40,8 +40,8 @@ exports.create = async (req, res, next) => {
       )
       .then((data) => JSON.parse(JSON.stringify(data)));
 
-    // feedServices.addFeed(1, '버킷리스트를 추가했습니다.');
-    res.status(OK).json({ message: '버킷 추가 성공' });
+    feedServices.addFeed(1, '버킷리스트를 추가했습니다.');
+    res.status(CREATED).json({ message: '버킷 추가 성공' });
   } catch (error) {
     next(error);
   }
@@ -55,7 +55,6 @@ exports.getBuckets = async (req, res, next) => {
   try {
     // TODO: 로그인 기능 구현후 주석 해제
     // const { userNo } = req.user;
-    // const buckets = await bucketServices.getBuckets(userNo);
     const buckets = await bucketServices.getBuckets(1);
     res.status(OK).json({
       message: '버킷 목록 조회 성공',
@@ -78,7 +77,7 @@ exports.updateBucket = async (req, res, next) => {
 
     if (status) result = await bucketServices.updateBucketStatus(no, status);
     else result = await bucketServices.updateBucketTitleDesc(no, title, description);
-
+    feedServices.addFeed(1, '버킷리스트를 수정했습니다.');
     if (result === 1) {
       res.status(OK).json({
         message: '버킷 수정 성공',

--- a/server/routes/bucket/controller.js
+++ b/server/routes/bucket/controller.js
@@ -1,6 +1,7 @@
 const { OK, CREATED, BAD_REQUEST } = require('../../config/statusCode').statusCode;
 const bucketServices = require('../../services/bucket');
 const detailServices = require('../../services/detail');
+const feedServices = require('../../services/feed');
 
 /*
     GET /api/buckets/presets
@@ -31,7 +32,7 @@ exports.create = async (req, res, next) => {
       .create(title, description, 1)
       .then((data) => JSON.parse(JSON.stringify(data)));
     const bucketNo = newBucket.no;
-    const newDetails = await detailServices
+    await detailServices
       .bulkCreate(
         details.map((detail) => {
           return { ...detail, bucketNo };
@@ -39,6 +40,7 @@ exports.create = async (req, res, next) => {
       )
       .then((data) => JSON.parse(JSON.stringify(data)));
 
+    // feedServices.addFeed(1, '버킷리스트를 추가했습니다.');
     res.status(OK).json({ message: '버킷 추가 성공' });
   } catch (error) {
     next(error);
@@ -55,7 +57,6 @@ exports.getBuckets = async (req, res, next) => {
     // const { userNo } = req.user;
     // const buckets = await bucketServices.getBuckets(userNo);
     const buckets = await bucketServices.getBuckets(1);
-
     res.status(OK).json({
       message: '버킷 목록 조회 성공',
       data: buckets,

--- a/server/routes/detail/controller.js
+++ b/server/routes/detail/controller.js
@@ -42,6 +42,7 @@ exports.updateDetail = async (req, res, next) => {
     else result = await detailServices.updateBucketTitleDueDate(no, title, dueDate);
 
     if (result === 1) {
+      feedServices.addFeed(1, '버킷 상세 목표를 수정했습니다.');
       res.status(OK).json({
         message: '버킷 상세 수정 성공',
         data: true,
@@ -67,6 +68,7 @@ exports.deleteDetail = async (req, res, next) => {
     const result = await detailServices.deleteDetail(no);
 
     if (result === 1) {
+      feedServices.addFeed(1, '버킷 상세 목표를 삭제했습니다.');
       res.status(OK).json({
         message: '버킷 상세 삭제 성공',
         data: true,
@@ -91,6 +93,7 @@ exports.createDetail = async (req, res, next) => {
     const { bucketNo, title, dueDate } = req.body;
 
     const detail = await detailServices.createDetail(bucketNo, title, dueDate);
+    feedServices.addFeed(1, '버킷 상세 목표를 추가했습니다.');
 
     res.status(CREATED).json({
       message: '버킷 상세 추가 성공',

--- a/server/routes/feed/controller.js
+++ b/server/routes/feed/controller.js
@@ -1,5 +1,6 @@
 const { OK } = require('../../config/statusCode').statusCode;
 const feedServices = require('../../services/feed');
+const followServices = require('../../services/follow');
 
 /*
     GET /api/feeds
@@ -8,7 +9,8 @@ const feedServices = require('../../services/feed');
 exports.getFeeds = async (req, res, next) => {
   try {
     // const { userNo } = req.user;
-    const feeds = await feedServices.getFeeds(1);
+    const followingList = await followServices.getFollowingList(1);
+    const feeds = await feedServices.getFeeds(followingList);
 
     res.status(OK).json({
       message: '피드 조회 성공',

--- a/server/routes/feed/controller.js
+++ b/server/routes/feed/controller.js
@@ -1,0 +1,20 @@
+const { OK } = require('../../config/statusCode').statusCode;
+const feedServices = require('../../services/feed');
+
+/*
+    GET /api/feeds
+    * 피드 조회 API
+*/
+exports.getFeeds = async (req, res, next) => {
+  try {
+    // const { userNo } = req.user;
+    const feeds = await feedServices.getFeeds(1);
+
+    res.status(OK).json({
+      message: '피드 조회 성공',
+      data: feeds,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/server/routes/feed/index.js
+++ b/server/routes/feed/index.js
@@ -1,0 +1,6 @@
+const router = require('express').Router();
+const controller = require('./controller');
+
+router.get('/', controller.getFeeds);
+
+module.exports = router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -5,6 +5,7 @@ const bucketRouter = require('./bucket');
 const achieveRouter = require('./achieve');
 const detailRouter = require('./detail');
 const followRouter = require('./follow');
+const feedRouter = require('./feed');
 
 router.use('/upload', uploadRouter);
 router.use('/users', userRouter);
@@ -12,5 +13,6 @@ router.use('/buckets', bucketRouter);
 router.use('/achieves', achieveRouter);
 router.use('/follows', followRouter);
 router.use('/details', detailRouter);
+router.use('/feeds', feedRouter);
 
 module.exports = router;

--- a/server/routes/user/controller.js
+++ b/server/routes/user/controller.js
@@ -21,7 +21,7 @@ exports.login = async (req, res, next) => {
 };
 
 /*
-    GET /api/user/list
+    GET /api/users
     * 전체 사용자 목록 조회 API
 */
 exports.getUsers = async (req, res, next) => {
@@ -52,5 +52,24 @@ exports.setUser = async (req, res, next) => {
     res.status(BAD_REQUEST).json({
       message: '사용자 가입 실패',
     });
+  }
+};
+
+/*
+    GET /api/users/info
+    * 사용자 정보 조회 API
+*/
+exports.getUserInfo = async (req, res, next) => {
+  try {
+    // const { no } = req.user;
+    const no = 1;
+    const user = await userServices.getUserInfo(no);
+
+    res.status(OK).json({
+      message: '사용자 정보 조회 성공',
+      data: user,
+    });
+  } catch (error) {
+    next(error);
   }
 };

--- a/server/routes/user/index.js
+++ b/server/routes/user/index.js
@@ -3,6 +3,7 @@ const middlewares = require('../../middlewares/auth');
 const controller = require('./controller');
 
 router.get('/', middlewares.jwtAuth, controller.getUsers);
+router.get('/info', controller.getUserInfo);
 router.post('/', controller.setUser);
 router.post('/login', middlewares.localAuth, controller.login);
 

--- a/server/services/db/feed.js
+++ b/server/services/db/feed.js
@@ -15,7 +15,7 @@ exports.selectFeeds = async (followings) => {
     raw: true,
     where: {
       userNo: { [Op.in]: followings },
-      createdAt: { [Op.gte]: lastWeek }, // 최대 일주일전
+      createdAt: { [Op.lte]: lastWeek }, // 최대 일주일전
     },
     order: [['created_at', 'DESC']], // 최근 순으로
     include: {

--- a/server/services/db/feed.js
+++ b/server/services/db/feed.js
@@ -1,0 +1,20 @@
+const { User, Feed } = require('../../models');
+
+exports.selectFeeds = async () => {
+  const results = await Feed.findAll({
+    raw: true,
+    include: [
+      {
+        models: User,
+      },
+    ],
+  });
+
+  return results;
+};
+
+exports.insertFeed = async (userNo, content) => {
+  const results = await Feed.create({ userNo, content });
+
+  return results;
+};

--- a/server/services/db/feed.js
+++ b/server/services/db/feed.js
@@ -1,13 +1,30 @@
-const { User, Feed } = require('../../models');
+const { User, Feed, Sequelize } = require('../../models');
+const lastWeek = require('../../utils/date');
 
-exports.selectFeeds = async () => {
+const { Op } = Sequelize;
+
+exports.selectFeeds = async (followings) => {
   const results = await Feed.findAll({
-    raw: true,
-    include: [
-      {
-        models: User,
-      },
+    attributes: [
+      'no',
+      'content',
+      'userNo',
+      ['created_at', 'date'],
+      [Sequelize.col('user.nickname'), 'nickname'],
     ],
+    raw: true,
+    where: {
+      userNo: { [Op.in]: followings },
+      createdAt: { [Op.gte]: lastWeek }, // 최대 일주일전
+    },
+    order: [['created_at', 'DESC']], // 최근 순으로
+    include: {
+      attributes: [],
+      model: User,
+      where: {
+        no: { [Op.col]: 'feed.user_no' },
+      },
+    },
   });
 
   return results;

--- a/server/services/db/follow.js
+++ b/server/services/db/follow.js
@@ -4,7 +4,7 @@ const { Follow } = require('../../models');
 exports.selectFollowingList = async (userNo) => {
   const result = await Follow.findAll({
     attributes: ['no', 'following_no', 'followed_no'],
-    where: { followed_no: userNo },
+    where: { following_no: userNo },
     raw: true,
   });
   return result;
@@ -13,7 +13,7 @@ exports.selectFollowingList = async (userNo) => {
 // 나를 팔로우 하는 사람 목록 조회
 exports.selectFollowedList = async (userNo) => {
   const result = await Follow.findAll({
-    where: { following_no: userNo },
+    where: { followed_no: userNo },
     raw: true,
   });
 

--- a/server/services/db/user.js
+++ b/server/services/db/user.js
@@ -1,5 +1,5 @@
 const { hashingPw } = require('../../utils/bcrypt');
-const { User } = require('../../models');
+const { User, Bucket } = require('../../models');
 
 exports.selectUserFromPassport = async (id) => {
   const results = await User.findOne({
@@ -30,5 +30,18 @@ exports.insertUser = async ({ id, password, nickname, description }) => {
 
   const results = await User.create(userData);
 
+  return results;
+};
+
+exports.selectUser = async (no) => {
+  const results = await User.findOne({
+    attributes: ['nickname', 'description', 'rank'],
+    include: [
+      {
+        model: Bucket,
+      },
+    ],
+    where: { no },
+  });
   return results;
 };

--- a/server/services/feed.js
+++ b/server/services/feed.js
@@ -1,0 +1,13 @@
+const db = require('./db/feed');
+
+exports.addFeed = async (userNo, content) => {
+  const result = await db.insertFeed(userNo, content);
+  return result;
+};
+
+exports.getFeeds = async (userNo) => {
+  const result = await db.selectFeeds(userNo);
+  // 팔로워 no 목록
+  // in 으로 userNo에 해당하는 것들만 출력
+  return result;
+};

--- a/server/services/feed.js
+++ b/server/services/feed.js
@@ -5,9 +5,8 @@ exports.addFeed = async (userNo, content) => {
   return result;
 };
 
-exports.getFeeds = async (userNo) => {
-  const result = await db.selectFeeds(userNo);
-  // 팔로워 no 목록
-  // in 으로 userNo에 해당하는 것들만 출력
+exports.getFeeds = async (followingList) => {
+  const followingUserNos = followingList.map((user) => user.followed_no);
+  const result = await db.selectFeeds(followingUserNos);
   return result;
 };

--- a/server/services/user.js
+++ b/server/services/user.js
@@ -1,4 +1,5 @@
 const db = require('./db/user');
+const fdb = require('./db/follow');
 
 /*
  * 전체 유저 조회
@@ -14,4 +15,26 @@ exports.getUsers = async () => {
 exports.setUser = async (data) => {
   const users = await db.insertUser(data);
   return users;
+};
+
+/*
+ * 유저 정보 조회
+ */
+exports.getUserInfo = async (no) => {
+  const user = await db.selectUser(no);
+  const follower = await fdb.selectFollowedList(no);
+  const following = await fdb.selectFollowingList(no);
+  const total = user.buckets.length;
+
+  const achieve = user.buckets.reduce((prev, bucket) => {
+    if (bucket.status === 'A') return prev + 1;
+    return prev;
+  }, 0);
+  delete user.dataValues.buckets;
+  const temp = { ...user.dataValues };
+  temp.achieveRate = Math.round((achieve / total) * 100);
+  temp.followerCount = follower.length;
+  temp.followingCount = following.length;
+
+  return temp;
 };

--- a/server/utils/date.js
+++ b/server/utils/date.js
@@ -1,0 +1,7 @@
+/* 오늘로부터 1주일전 날짜 반환 */
+exports.lastWeek = () => {
+  const d = new Date();
+  const dayOfMonth = d.getDate();
+  d.setDate(dayOfMonth - 7);
+  return getDateStr(d);
+};


### PR DESCRIPTION
## 구현의도
- 피드 테이블을 생성하고 데이터를 추가, 조회만 가능하도록 API 구현
- 최근 일주일 전까지의 기록만 가져오도록 구현
- 팔로우한 사용자들의 기록만 가져오도록 구현

## API 명세 
### 피드 조회 API
Request
```
GET /api/feeds
```

Response

```
{
    "message": "피드 조회 성공",
    "data": [
        {
            "no": 2,
            "content": "상세 목표를 수정했습니다.",
            "userNo": 4,
            "date": "2020-12-09 01:34:27",
            "nickname": "멤버"
        },
        {
            "no": 1,
            "content": "버킷리스트를 추가했습니다.",
            "userNo": 2,
            "date": "2020-12-09 01:04:46",
            "nickname": "부스트"
        }
    ]
}
```

## 논의사항
- 피드를 추가하는 API를 별도로 만들지않고 각 API에서 호출하는 방식으로 사용하려고 하는게 어떻게 생각하시나요?