### PR TITLE
[SIDEBAR (FIX)] 소감 생성 페이지 레이아웃 수정 및 데이터 연결

### DIFF
--- a/sidebar/src/components/UI/organisms/detail_header/index.js
+++ b/sidebar/src/components/UI/organisms/detail_header/index.js
@@ -49,7 +49,7 @@ const DetailHeader = ({ bucket, achieveDisable, isAchieve }) => {
     params.no = bucket.no;
     params.status = ACHIEVE;
     dispatch(updateBucketStatus(params));
-    history.push(`/achieves/${bucket.no}/create`);
+    history.push({ pathname: `/achieves/${bucket.no}/create`, state: { bucket } });
   };
 
   return (

--- a/sidebar/src/components/UI/organisms/line_bar_area_composed_chart/index.js
+++ b/sidebar/src/components/UI/organisms/line_bar_area_composed_chart/index.js
@@ -13,7 +13,7 @@ const LineBarAreaComposedChart = ({ detailTot }) => {
   }, []);
 
   useEffect(() => {
-    setData(detailTot.burnDownChart);
+    setTimeout(() => setData(detailTot.burnDownChart), 2000);
   }, [detailTot]);
 
   return (

--- a/sidebar/src/components/UI/organisms/pie_chart/index.js
+++ b/sidebar/src/components/UI/organisms/pie_chart/index.js
@@ -74,10 +74,14 @@ const PieChart1 = ({ detailTot }) => {
   };
 
   useEffect(() => {
-    setData([
-      { name: '진행 중', value: detailTot.details.openDetails.length },
-      { name: '달성', value: detailTot.details.achieveDetails.length },
-    ]);
+    setTimeout(
+      () =>
+        setData([
+          { name: '진행 중', value: detailTot.details.openDetails.length },
+          { name: '달성', value: detailTot.details.achieveDetails.length },
+        ]),
+      1000
+    );
   }, [detailTot]);
   return (
     <PieChart

--- a/sidebar/src/components/pages/AchieveCreatePage.js
+++ b/sidebar/src/components/pages/AchieveCreatePage.js
@@ -1,20 +1,16 @@
-import React, { useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import { reset, changeInput, setAchieve } from '../../modules/achieve';
 import AchieveCreateLayout from '../templates/achieve_create';
 import Header from '../UI/organisms/header';
 
-const bucketState = {
-  bucket: '부스트캠프 수료',
-  description: '멤버십을 훌륭하게 해내고 싶습니다. ',
-  date: '2020.07.27',
-};
-
 const AchieveCreatePage = ({ match }) => {
+  const location = useLocation();
+  const [bucketState, setBucket] = useState({});
   const { bucketNo } = match.params;
-  const acheiveState = useSelector((state) => state.acheiveState, []);
+  const acheiveState = useSelector((state) => state.acheiveState);
   const dispatch = useDispatch();
   const history = useHistory();
 
@@ -29,9 +25,19 @@ const AchieveCreatePage = ({ match }) => {
   useEffect(() => {
     if (acheiveState.message) {
       dispatch(reset());
-      history.replace(`/achieves/${bucketNo}/result`);
+      history.replace(`/detail/${bucketNo}`);
     }
   }, [acheiveState]);
+
+  useEffect(() => {
+    // url 직접 접근 제한
+    if (!location.state) {
+      history.goBack();
+      return;
+    }
+    const { bucket } = location.state;
+    setBucket(bucket);
+  }, []);
 
   return (
     <>

--- a/sidebar/src/components/templates/achieve_create/index.js
+++ b/sidebar/src/components/templates/achieve_create/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
-
+import Typography from '@material-ui/core/Typography';
+import Divider from '@material-ui/core/Divider';
 import useStyles from './style';
-
 import WritingTab from '../../UI/organisms/writing_tab';
 
 const AchieveCreate = ({ bucketState, acheiveState, changeAchieve, submitAchieve }) => {
@@ -12,10 +12,18 @@ const AchieveCreate = ({ bucketState, acheiveState, changeAchieve, submitAchieve
       <div className={classes.header} />
       <div className={classes.page}>
         <div className="bucketInfo">
-          <div>〈목표 달성!〉</div>
-          <h1>#01 {bucketState.bucket}</h1>
-          <p>{bucketState.description}</p>
-          <p>from {bucketState.date}</p>
+          <Typography className={classes.title}>
+            #{bucketState.no} 〈<span className={classes.bigTitle}>{bucketState.title}</span>〉
+            목표를 달성한 소감을 알려주세요.
+          </Typography>
+          {/* <Divider /> */}
+          <Typography>
+            from
+            <span className={classes.date}>{String(bucketState.createdAt).substring(0, 10)}</span>
+            to
+            <span className={classes.date}>{String(bucketState.updatedAt).substring(0, 10)}</span>
+          </Typography>
+          <Typography className={classes.description}>{bucketState.description}</Typography>
         </div>
         <div className="writeImpression">
           <WritingTab

--- a/sidebar/src/components/templates/achieve_create/style.js
+++ b/sidebar/src/components/templates/achieve_create/style.js
@@ -19,9 +19,28 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'flex-end',
   },
   page: {
-    width: '85vw',
-    'max-width': 'calc(100% - 140px)',
     margin: '0 auto',
+  },
+  title: {
+    fontSize: '1.2rem',
+  },
+  bigTitle: {
+    padding: theme.spacing(2),
+    fontSize: '3rem',
+    fontWeight: 'bold',
+    fontFamily: 'Nanum Brush Script, sans-serif !important',
+  },
+  date: {
+    padding: theme.spacing(2),
+    fontSize: '1.5rem',
+    fontFamily: 'Nanum Brush Script, sans-serif !important',
+  },
+  description: {
+    padding: theme.spacing(3),
+    marginTop: theme.spacing(3),
+    marginBottom: theme.spacing(3),
+    border: '1px solid #eeeeee',
+    borderRadius: '5px',
   },
 }));
 

--- a/sidebar/src/modules/details.js
+++ b/sidebar/src/modules/details.js
@@ -107,14 +107,10 @@ const getDeleteDetail = ({ details }, { no }) => {
   return details;
 };
 
-const getDeleteBurndownChart = (state) => formattingBurndownChart(getDeleteDetail(state));
-
 const getNewDetails = ({ details }, { detail }) => {
   insertDetail(details.openDetails, detail);
   return details;
 };
-
-const getNewBurndownChart = (state) => formattingBurndownChart(getNewDetails(state));
 
 const details = handleActions(
   {
@@ -131,12 +127,12 @@ const details = handleActions(
     [DELETE_DETAIL_SUCCESS]: (state, action) => ({
       ...state,
       buckets: getDeleteDetail(state, action.params),
-      burnDownChart: getDeleteBurndownChart(state),
+      burnDownChart: getUpdateBurndownChart(state),
     }),
     [CREATE_DETAIL_SUCCESS]: (state, action) => ({
       ...state,
       buckets: getNewDetails(state, action.payload.data),
-      burnDownChart: getNewBurndownChart(state),
+      burnDownChart: getUpdateBurndownChart(state),
     }),
   },
   initialState


### PR DESCRIPTION
## 구현의도

- 상세 목표 추가 삭제 시 발생하는 오류 수정
- 소감 생성 페이지 레이아웃 수정
- 소감 작성 페이지 bucket 정보 연결 및 url 직접 접근 제한
- recharts 모듈의 애니메이션 에러 해결을 위해 딜레이 추가
- location 객체에 bucket state 저장해서 redirect하기

## 화면
![screenshot-localhost-3000-1607533771881](https://user-images.githubusercontent.com/46799722/101662688-2c1f9880-3a8d-11eb-9b52-4435dba0c3b8.png)

