### PR TITLE
[iOS #55] 에러 수정, NWPathMonitor 구현

### DIFF
--- a/iOS/project04/project04.xcodeproj/project.pbxproj
+++ b/iOS/project04/project04.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		C1655CA1256B7ED30067E3C5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C1655C9F256B7ED30067E3C5 /* LaunchScreen.storyboard */; };
 		C168BF612576873700A1A338 /* extension+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = C168BF602576873700A1A338 /* extension+Date.swift */; };
 		C168DD972580EBC100EE3849 /* UserToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = C168DD962580EBC100EE3849 /* UserToken.swift */; };
+		C168DD9E258100B500EE3849 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C168DD9D258100B500EE3849 /* NetworkPathMonitor.swift */; };
 		C16BEFB52579CF2000108265 /* extension+UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16BEFB42579CF2000108265 /* extension+UIColor.swift */; };
 		C1754EDC256E13650037C805 /* DetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1754EDB256E13650037C805 /* DetailRepository.swift */; };
 		C1754EE3256E17F20037C805 /* LocalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1754EE2256E17F20037C805 /* LocalService.swift */; };
@@ -165,6 +166,7 @@
 		C1655CA2256B7ED30067E3C5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C168BF602576873700A1A338 /* extension+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "extension+Date.swift"; sourceTree = "<group>"; };
 		C168DD962580EBC100EE3849 /* UserToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserToken.swift; sourceTree = "<group>"; };
+		C168DD9D258100B500EE3849 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
 		C16BEFB42579CF2000108265 /* extension+UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "extension+UIColor.swift"; sourceTree = "<group>"; };
 		C1754EDB256E13650037C805 /* DetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailRepository.swift; sourceTree = "<group>"; };
 		C1754EE2256E17F20037C805 /* LocalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalService.swift; sourceTree = "<group>"; };
@@ -342,6 +344,7 @@
 			isa = PBXGroup;
 			children = (
 				82E8ACB6257F721B00041785 /* NetworkService.swift */,
+				C168DD9D258100B500EE3849 /* NetworkPathMonitor.swift */,
 			);
 			path = Singleton;
 			sourceTree = "<group>";
@@ -842,6 +845,7 @@
 				8285704F257FBA4300E3FEA9 /* Response.swift in Sources */,
 				C1269C8C257F343A00A5C1EC /* LoginCoordinator.swift in Sources */,
 				C1269C92257F3A7900A5C1EC /* LoginAPIAgent.swift in Sources */,
+				C168DD9E258100B500EE3849 /* NetworkPathMonitor.swift in Sources */,
 				8215F5242579A81800DDCD09 /* BucketListSearchViewModel.swift in Sources */,
 				C1655C95256B7ED10067E3C5 /* AppDelegate.swift in Sources */,
 				82857053257FBAA200E3FEA9 /* ResponseBucket.swift in Sources */,

--- a/iOS/project04/project04/App/SceneDelegate.swift
+++ b/iOS/project04/project04/App/SceneDelegate.swift
@@ -29,6 +29,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
+        let monitor = NetworkStatus.shared
     }
 
     func sceneWillResignActive(_ scene: UIScene) {

--- a/iOS/project04/project04/Coordinator/LoginCoordinator.swift
+++ b/iOS/project04/project04/Coordinator/LoginCoordinator.swift
@@ -25,7 +25,7 @@ class LoginCoordinator: NavigationCoordinator {
     
     func presentTabBarController() {
         let viewController = MainTabBarController()
-        navigationController.popViewController(animated: false)
+        navigationController.viewControllers.removeAll()
         navigationController.pushViewController(viewController, animated: true)
     }
 }

--- a/iOS/project04/project04/Scene/DetailList/View/DetailListViewController.swift
+++ b/iOS/project04/project04/Scene/DetailList/View/DetailListViewController.swift
@@ -47,7 +47,6 @@ class DetailListViewController: UIViewController, ImpressionDelegate {
         title = bucket?.title
         configureHierarchy()
         configureDataSource()
-        print(bucket?.no)
         collectionViewModel?.listDidChange = { [weak self] viewModel in
             DispatchQueue.main.async {
                 self?.updateList()
@@ -71,7 +70,6 @@ class DetailListViewController: UIViewController, ImpressionDelegate {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         detailSuccessChecker(viewModel: collectionViewModel)
-        animatePieView(viewModel: collectionViewModel)
     }
     
     @IBAction func detailAppendAction(_ sender: UIBarButtonItem) {

--- a/iOS/project04/project04/Util/Singleton/NetworkPathMonitor.swift
+++ b/iOS/project04/project04/Util/Singleton/NetworkPathMonitor.swift
@@ -1,0 +1,41 @@
+//
+//  NetworkPathMonitor.swift
+//  project04
+//
+//  Created by 남기범 on 2020/12/09.
+//
+
+import Foundation
+import Network
+
+public enum ConnectionType {
+    case wifi
+    case ethernet
+    case cellular
+    case unknown
+}
+
+class NetworkStatus {
+    static public let shared = NetworkStatus()
+    private var monitor: NWPathMonitor
+    private var queue = DispatchQueue.global()
+
+    private init() {
+        self.monitor = NWPathMonitor()
+        self.queue = DispatchQueue.global(qos: .background)
+        
+        self.monitor.pathUpdateHandler = { path in
+            if path.status == .satisfied {
+                print("good")
+            } else {
+                print("not good")
+            }
+        }
+        
+        self.monitor.start(queue: queue)
+    }
+
+    func stop() {
+        self.monitor.cancel()
+    }
+}


### PR DESCRIPTION
## 구현의도
- NWPathMonitor를 사용하기로 정해서 간단하게 샘플코드로 네트워크 상황을 체크 해봤습니다.
- 원형 그래프가 연속해서 2번 그려지는 현상이 있어서 한번만 그려지게 수정했습니다.
- 로그인 이후에도 로그인 화면이 남아있어서 로그인 화면을 삭제해줬습니다.