### PR TITLE
[iOS #55] 오프라인 데이터 연동 기능 구현

### DIFF
--- a/iOS/project04/project04.xcodeproj/project.pbxproj
+++ b/iOS/project04/project04.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		82DDAEFF2580528C0033F39A /* SearchBucket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82DDAEFE2580528C0033F39A /* SearchBucket.swift */; };
 		82E8AC9E257F1F6600041785 /* DetailMemoryAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E8AC9D257F1F6600041785 /* DetailMemoryAgent.swift */; };
 		82E8ACB7257F721B00041785 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E8ACB6257F721B00041785 /* NetworkService.swift */; };
+		82E8B7542581C0040008A22A /* RealmTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E8B7532581C0040008A22A /* RealmTransaction.swift */; };
 		82F12FD12579AD620079DB71 /* BucketListSearchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F12FD02579AD620079DB71 /* BucketListSearchUseCase.swift */; };
 		82F12FD82579B59C0079DB71 /* BucketListSearchRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F12FD72579B59C0079DB71 /* BucketListSearchRepository.swift */; };
 		B20CB3CD1814FA9193815C42 /* Pods_project04.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 549A8B673E411EE0B839D8C7 /* Pods_project04.framework */; };
@@ -128,6 +129,7 @@
 		82DDAEFE2580528C0033F39A /* SearchBucket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBucket.swift; sourceTree = "<group>"; };
 		82E8AC9D257F1F6600041785 /* DetailMemoryAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailMemoryAgent.swift; sourceTree = "<group>"; };
 		82E8ACB6257F721B00041785 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
+		82E8B7532581C0040008A22A /* RealmTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmTransaction.swift; sourceTree = "<group>"; };
 		82F12FD02579AD620079DB71 /* BucketListSearchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketListSearchUseCase.swift; sourceTree = "<group>"; };
 		82F12FD72579B59C0079DB71 /* BucketListSearchRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketListSearchRepository.swift; sourceTree = "<group>"; };
 		C11AC45F256B7F8B00E45667 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
@@ -555,6 +557,7 @@
 				C175D19A256CCF3C001144F0 /* RealmDetailList.swift */,
 				82A7291E256F4BCB00BD5797 /* RealmBucket.swift */,
 				C1604D0C257DFC450019E6E2 /* RealmImpression.swift */,
+				82E8B7532581C0040008A22A /* RealmTransaction.swift */,
 			);
 			path = RealmObject;
 			sourceTree = "<group>";
@@ -868,6 +871,7 @@
 				C175D19B256CCF3C001144F0 /* RealmDetailList.swift in Sources */,
 				C1E6C41F2574E83200BD4B4B /* NavigationCoordinator.swift in Sources */,
 				C160DBB025776DB800290EAE /* DetailSectionImpressionHeaderView.swift in Sources */,
+				82E8B7542581C0040008A22A /* RealmTransaction.swift in Sources */,
 				C16019C025792FEE00506430 /* DetailSectionGraphView.swift in Sources */,
 				C160C4D8257DC84100578BE3 /* ImpressionViewController.swift in Sources */,
 				C1754EF5256E1B8B0037C805 /* HTTPMethod.swift in Sources */,

--- a/iOS/project04/project04.xcodeproj/project.pbxproj
+++ b/iOS/project04/project04.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		82E8AC9E257F1F6600041785 /* DetailMemoryAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E8AC9D257F1F6600041785 /* DetailMemoryAgent.swift */; };
 		82E8ACB7257F721B00041785 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E8ACB6257F721B00041785 /* NetworkService.swift */; };
 		82E8B7542581C0040008A22A /* RealmTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E8B7532581C0040008A22A /* RealmTransaction.swift */; };
+		82E8B7582581C0D20008A22A /* TransactionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E8B7572581C0D20008A22A /* TransactionRecorder.swift */; };
 		82F12FD12579AD620079DB71 /* BucketListSearchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F12FD02579AD620079DB71 /* BucketListSearchUseCase.swift */; };
 		82F12FD82579B59C0079DB71 /* BucketListSearchRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F12FD72579B59C0079DB71 /* BucketListSearchRepository.swift */; };
 		B20CB3CD1814FA9193815C42 /* Pods_project04.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 549A8B673E411EE0B839D8C7 /* Pods_project04.framework */; };
@@ -130,6 +131,7 @@
 		82E8AC9D257F1F6600041785 /* DetailMemoryAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailMemoryAgent.swift; sourceTree = "<group>"; };
 		82E8ACB6257F721B00041785 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		82E8B7532581C0040008A22A /* RealmTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmTransaction.swift; sourceTree = "<group>"; };
+		82E8B7572581C0D20008A22A /* TransactionRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionRecorder.swift; sourceTree = "<group>"; };
 		82F12FD02579AD620079DB71 /* BucketListSearchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketListSearchUseCase.swift; sourceTree = "<group>"; };
 		82F12FD72579B59C0079DB71 /* BucketListSearchRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketListSearchRepository.swift; sourceTree = "<group>"; };
 		C11AC45F256B7F8B00E45667 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
@@ -347,6 +349,7 @@
 			children = (
 				82E8ACB6257F721B00041785 /* NetworkService.swift */,
 				C168DD9D258100B500EE3849 /* NetworkPathMonitor.swift */,
+				82E8B7572581C0D20008A22A /* TransactionRecorder.swift */,
 			);
 			path = Singleton;
 			sourceTree = "<group>";
@@ -832,6 +835,7 @@
 				82A72917256F43E100BD5797 /* BucketLocalAgent.swift in Sources */,
 				82F12FD82579B59C0079DB71 /* BucketListSearchRepository.swift in Sources */,
 				C1E6C4172574D45900BD4B4B /* MainTabBarController.swift in Sources */,
+				82E8B7582581C0D20008A22A /* TransactionRecorder.swift in Sources */,
 				C168BF612576873700A1A338 /* extension+Date.swift in Sources */,
 				C1754F07256E4AC00037C805 /* ListUseCase.swift in Sources */,
 				C1BFAD0B25761BF300BDEF93 /* RoundButton.swift in Sources */,

--- a/iOS/project04/project04/App/SceneDelegate.swift
+++ b/iOS/project04/project04/App/SceneDelegate.swift
@@ -16,12 +16,21 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         let navigationController = UINavigationController()
-        let controller = UIStoryboard(name: "Login", bundle: nil).instantiateViewController(identifier: "LoginViewController", creator: { coder in
-            let coordinator = LoginCoordinator(navigationController)
-            return LoginViewController(coder: coder, coordinator: coordinator)
-        })
-        navigationController.pushViewController(controller, animated: false)
-        window?.rootViewController = navigationController
+        var controller: UIViewController
+        
+        let auth = AccessToken()
+        if auth.token.isEmpty {
+            controller = UIStoryboard(name: "Login", bundle: nil).instantiateViewController(identifier: "LoginViewController", creator: { coder in
+                let coordinator = LoginCoordinator(navigationController)
+                return LoginViewController(coder: coder, coordinator: coordinator)
+            })
+            window?.rootViewController = navigationController
+            navigationController.pushViewController(controller, animated: false)
+
+        } else {
+            controller = MainTabBarController()
+            window?.rootViewController = controller
+        }
         window?.makeKeyAndVisible()
     }
 

--- a/iOS/project04/project04/App/SceneDelegate.swift
+++ b/iOS/project04/project04/App/SceneDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-
+    let monitor = NetworkStatus.shared
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
@@ -29,7 +29,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        let monitor = NetworkStatus.shared
     }
 
     func sceneWillResignActive(_ scene: UIScene) {

--- a/iOS/project04/project04/Model/RealmObject/RealmImpression.swift
+++ b/iOS/project04/project04/Model/RealmObject/RealmImpression.swift
@@ -8,16 +8,13 @@
 import Foundation
 import RealmSwift
 
-struct Impression: Codable {
-    let message: String
-    let data: RealmImpression
-}
-
 class RealmImpression: Object, Codable {
+    @objc dynamic var no: Int = 0
     @objc dynamic var text: String = ""
     @objc dynamic var bucketNo: Int = 0
     
     private enum CodingKeys: String, CodingKey {
+        case no
         case text = "description"
         case bucketNo
     }

--- a/iOS/project04/project04/Model/RealmObject/RealmTransaction.swift
+++ b/iOS/project04/project04/Model/RealmObject/RealmTransaction.swift
@@ -1,0 +1,15 @@
+//
+//  RealmTransaction.swift
+//  project04
+//
+//  Created by jaejeon on 2020/12/10.
+//
+
+import Foundation
+import RealmSwift
+
+class RealmTransaction: Object {
+    @objc dynamic var endpointURL: String = ""
+    @objc dynamic var method: String = ""
+    @objc dynamic var data: Data = Data()
+}

--- a/iOS/project04/project04/Model/RealmObject/RealmTransaction.swift
+++ b/iOS/project04/project04/Model/RealmObject/RealmTransaction.swift
@@ -9,7 +9,7 @@ import Foundation
 import RealmSwift
 
 class RealmTransaction: Object {
-    @objc dynamic var endpointURL: String = ""
+    @objc dynamic var url: String = ""
     @objc dynamic var method: String = ""
-    @objc dynamic var data: Data = Data()
+    @objc dynamic var data: Data? = nil
 }

--- a/iOS/project04/project04/Scene/BucketList/Repository/BucketLocalAgent.swift
+++ b/iOS/project04/project04/Scene/BucketList/Repository/BucketLocalAgent.swift
@@ -59,4 +59,18 @@ class BucketLocalAgent: LocalService {
             print(error)
         }
     }
+    
+    func sync(buckets: [RealmBucket]) {
+        do {
+            let realm = try Realm()
+            let result = realm.objects(RealmBucket.self)
+            
+            try realm.write {
+                realm.delete(result)
+                realm.add(buckets)
+            }
+        } catch {
+            print(error)
+        }
+    }
 }

--- a/iOS/project04/project04/Scene/BucketListSearch/Repository/BucketListSearchRepository.swift
+++ b/iOS/project04/project04/Scene/BucketListSearch/Repository/BucketListSearchRepository.swift
@@ -18,11 +18,14 @@ class BucketListSearchRepository: SearchRepositoryProtocol {
             switch result {
             case .success(let data):
                 let response = try? JSONDecoder().decode(Response<[SearchBucket]>.self, from: data)
-                list = response?.data
-            case .failure(_):
+                DispatchQueue.main.async {
+                    completion(response?.data ?? [])
+                }
+            case .failure(let error):
+                print(error)
                 break
             }
-            completion(list ?? [])
+            
         }
     }
     

--- a/iOS/project04/project04/Scene/BucketListSearch/View/BucketListSearchViewController.swift
+++ b/iOS/project04/project04/Scene/BucketListSearch/View/BucketListSearchViewController.swift
@@ -20,8 +20,9 @@ class BucketListSearchViewController: UITableViewController {
     
     init?(coder: NSCoder, viewModel: BucketListSearchViewModelProtocol, didSelectRowHandler: @escaping (SearchBucket) -> Void) {
         self.viewModel = viewModel
+
+        self.viewModel.fetch()
         self.didSelectRowHandler = didSelectRowHandler
-        viewModel.fetch()
         super.init(coder: coder)
     }
     
@@ -32,6 +33,10 @@ class BucketListSearchViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureSearchController()
+        self.viewModel.handler = {
+            self.tableView.reloadData()
+        }
+        self.viewModel.fetch()
     }
     
     func isFiltering() -> Bool {

--- a/iOS/project04/project04/Scene/BucketListSearch/ViewModel/BucketListSearchViewModel.swift
+++ b/iOS/project04/project04/Scene/BucketListSearch/ViewModel/BucketListSearchViewModel.swift
@@ -43,6 +43,7 @@ class BucketListSearchViewModel: BucketListSearchViewModelProtocol {
     func fetch() {
         usecase.fetch { [weak self] (buckets) in
             self?.buckets = buckets
+            self?.handler?()
         }
     }
     

--- a/iOS/project04/project04/Scene/DetailList/Repository/DetailLocalAgent.swift
+++ b/iOS/project04/project04/Scene/DetailList/Repository/DetailLocalAgent.swift
@@ -81,6 +81,7 @@ class DetailLocalAgent: LocalService {
         do {
             let realm = try Realm()
             let result = realm.objects(RealmDetail.self)
+            
             try realm.write {
                 realm.delete(result)
                 realm.add(details)

--- a/iOS/project04/project04/Scene/DetailList/Repository/DetailLocalAgent.swift
+++ b/iOS/project04/project04/Scene/DetailList/Repository/DetailLocalAgent.swift
@@ -76,4 +76,17 @@ class DetailLocalAgent: LocalService {
     func revise(at index: Int, element: RealmDetail) {
          
     }
+    
+    func sync(details: [RealmDetail]) {
+        do {
+            let realm = try Realm()
+            let result = realm.objects(RealmDetail.self)
+            try realm.write {
+                realm.delete(result)
+                realm.add(details)
+            }
+        } catch {
+            print(error)
+        }
+    }
 }

--- a/iOS/project04/project04/Scene/DetailList/Repository/DetailRepository.swift
+++ b/iOS/project04/project04/Scene/DetailList/Repository/DetailRepository.swift
@@ -30,7 +30,9 @@ class DetailRepository: DetailRepositoryProtocol {
                                         switch result {
                                         case .success(let data):
                                             let detailFetch = try? JSONDecoder().decode(Response<Info>.self, from: data)
-                                            self?.local.sync(details: detailFetch?.data.details.allDetails ?? [])
+                                            DispatchQueue.main.async {
+                                                self?.local.sync(details: detailFetch?.data.details.allDetails ?? [])
+                                            }
                                         case .failure(let error):
                                             print(error)
                                             
@@ -50,14 +52,18 @@ class DetailRepository: DetailRepositoryProtocol {
                                       body: data,
                                       completion: { [weak self] result in
                                         switch result {
-                                        case .success(_):
+                                        case .success(let data):
+                                            let response = try? JSONDecoder().decode(Response<[String: RealmDetail]>.self, from: data)
+                                            let detail = response?.data["detail"]
+                                            element.no = detail?.no ?? 0
                                             break
                                         case .failure(let error):
                                             print(error)
-                                            DispatchQueue.main.async {
-                                                self?.local.append(element)
-                                            }
+                                            
                                             TransactionRecorder.shared.record(url: Endpoint.details.urlString, method: .POST, data: data)
+                                        }
+                                        DispatchQueue.main.async {
+                                            self?.local.append(element)
                                         }
                                       })
     }

--- a/iOS/project04/project04/Scene/DetailList/Repository/DetailRepository.swift
+++ b/iOS/project04/project04/Scene/DetailList/Repository/DetailRepository.swift
@@ -24,23 +24,27 @@ class DetailRepository: DetailRepositoryProtocol {
     
     func fetchDetailList(bucketNo: Int, completion: @escaping ([RealmDetail]) -> Void) {
         
-        // RealmBucket 인자가 다름
         NetworkService.shared.request(from: Endpoint.details.urlString + "/\(bucketNo)",
                                       method: .GET,
                                       completion: { [weak self] result in
                                         switch result {
                                         case .success(let data):
                                             let detailFetch = try? JSONDecoder().decode(Response<Info>.self, from: data)
-                                            completion(detailFetch?.data.details.allDetails ?? [])
+                                            self?.local.sync(details: detailFetch?.data.details.allDetails ?? [])
                                         case .failure(let error):
                                             print(error)
+                                            
+                                        }
+                                        DispatchQueue.main.async {
                                             completion(self?.local.load() ?? [])
                                         }
                                       })
+        
     }
     
     func appendDetailList(_ element: RealmDetail) {
         let data = try? JSONEncoder().encode(["bucketNo": "\(element.bucketNo)", "title": element.title, "dueDate": element.dueDate])
+        
         NetworkService.shared.request(from: Endpoint.details.urlString,
                                       method: .POST,
                                       body: data,
@@ -50,29 +54,34 @@ class DetailRepository: DetailRepositoryProtocol {
                                             break
                                         case .failure(let error):
                                             print(error)
-                                            self?.local.append(element)
+                                            DispatchQueue.main.async {
+                                                self?.local.append(element)
+                                            }
+                                            TransactionRecorder.shared.record(url: Endpoint.details.urlString, method: .POST, data: data)
                                         }
                                       })
     }
     
     func removeDetailList(at index: Int) {
-        NetworkService.shared.request(from: Endpoint.details.urlString + "/\(index)",
+        let url = Endpoint.details.urlString + "/\(index)"
+        NetworkService.shared.request(from: url,
                                       method: .DELETE,
                                       completion: {  result in
                                         switch result {
                                         case .success(_):
                                             break
                                         case .failure(_):
-                                            break
+                                            TransactionRecorder.shared.record(url: url, method: .DELETE, data: nil)
                                         }
             
         })
-//        local.remove(at: index)
+        local.remove(at: index)
     }
     
     func reviseDetailList(element: RealmDetail, title: String, dueDate: String) {
         let data = try? JSONEncoder().encode(["title": title, "dueDate": dueDate])
-        NetworkService.shared.request(from: Endpoint.details.urlString + "/\(element.no)",
+        let url = Endpoint.details.urlString + "/\(element.no)"
+        NetworkService.shared.request(from: url,
                                       method: .PATCH,
                                       body: data,
                                       completion: { result in
@@ -80,24 +89,24 @@ class DetailRepository: DetailRepositoryProtocol {
                                         case .success(_):
                                             break
                                         case .failure(_):
-                                            break
+                                            TransactionRecorder.shared.record(url: url, method: .PATCH, data: data)
                                         }
                                       })
         local.revise(element: element, title: title, dueDate: dueDate)
     }
     
     func reviseDetailListStatus(element: RealmDetail) {
-        print(element.bucketNo)
         let data = try? JSONEncoder().encode(["status": "A"])
-        NetworkService.shared.request(from: Endpoint.details.urlString + "/\(element.no)",
+        let url = Endpoint.details.urlString + "/\(element.no)"
+        NetworkService.shared.request(from: url,
                                       method: .PATCH,
                                       body: data,
                                       completion: { result in
                                         switch result {
-                                        case .success(let data):
-                                            print(String(data: data, encoding: .utf8))
-                                        case .failure(let error):
-                                            print(error)
+                                        case .success(_):
+                                            break
+                                        case .failure(_):
+                                            TransactionRecorder.shared.record(url: url, method: .PATCH, data: data)
                                         }
                                       })
         

--- a/iOS/project04/project04/Scene/DetailList/View/DetailListAddViewController.swift
+++ b/iOS/project04/project04/Scene/DetailList/View/DetailListAddViewController.swift
@@ -85,6 +85,7 @@ class DetailListAddViewController: UIViewController {
                                                      nil,
                                                      index ?? 0]
             ))
+            
             dismiss(animated: false, completion: nil)
             return
         }

--- a/iOS/project04/project04/Scene/DetailList/View/DetailListViewController.swift
+++ b/iOS/project04/project04/Scene/DetailList/View/DetailListViewController.swift
@@ -210,7 +210,9 @@ extension DetailListViewController {
         
         snapshot.appendItems(collectionViewModel?.list[.todo] ?? [], toSection: .todo)
         snapshot.appendItems(collectionViewModel?.list[.done] ?? [], toSection: .done)
+        
         dataSource.apply(snapshot, animatingDifferences: false)
+        
     }
     
     private func configureSuccessHandler() {

--- a/iOS/project04/project04/Scene/Impression/Repository/ImpressionLocalAgent.swift
+++ b/iOS/project04/project04/Scene/Impression/Repository/ImpressionLocalAgent.swift
@@ -10,7 +10,7 @@ import RealmSwift
 
 protocol ImpressionLocalAgentProtocol {
     func fetch(bucketNo: Int) -> RealmImpression?
-    func save(text: String)
+    func save(_ element: RealmImpression)
     func edit(element: RealmImpression, text: String)
 }
 
@@ -26,15 +26,14 @@ class ImpressionLocalAgent {
         }
     }
     
-    func save(bucketNo: Int, text: String) {
+    func save(_ element: RealmImpression) {
         do {
             let realm = try Realm()
             
             try realm.write {
-                let object = realm.objects(RealmImpression.self).filter("#bucketNo == \(bucketNo)")
-                realm.delete(object)
-                let impression = RealmImpression(value: [text, bucketNo])
-                realm.add(impression)
+//                let object = realm.objects(RealmImpression.self).filter("#bucketNo == \(element.bucketNo)")
+//                realm.delete(object)
+                realm.add(element)
             }
         } catch {
             print(error)
@@ -45,6 +44,24 @@ class ImpressionLocalAgent {
         do {
             try Realm().write {
                 element?.text = text
+            }
+        } catch {
+            print(error)
+        }
+    }
+    
+    func sync(impression: RealmImpression?) {
+        guard let impression = impression else {
+            return
+        }
+        do {
+            let realm = try Realm()
+            let result = realm.objects(RealmImpression.self).filter("#bucketNo == \(impression.bucketNo)").first
+            try realm.write {
+                if let object = result {
+                    realm.delete(object)
+                }
+                realm.add(impression)
             }
         } catch {
             print(error)

--- a/iOS/project04/project04/Scene/Impression/UseCase/ImpressionUseCase.swift
+++ b/iOS/project04/project04/Scene/Impression/UseCase/ImpressionUseCase.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol ImpressionUseCaseProtocol {
     func fetch(bucketNo: Int, completion: @escaping (RealmImpression?) -> Void)
-    func save(bucketNo: Int, text: String)
+    func save(_ element: RealmImpression)
     func edit(element: RealmImpression?, text: String)
 }
 
@@ -26,8 +26,8 @@ class ImpressionUseCase: ImpressionUseCaseProtocol {
         })
     }
     
-    func save(bucketNo: Int, text: String) {
-        repository.saveImpression(bucketNo: bucketNo, text: text)
+    func save(_ element: RealmImpression) {
+        repository.saveImpression(element)
     }
     
     func edit(element: RealmImpression?, text: String) {

--- a/iOS/project04/project04/Scene/Impression/View/ImpressionViewController.swift
+++ b/iOS/project04/project04/Scene/Impression/View/ImpressionViewController.swift
@@ -44,7 +44,8 @@ class ImpressionViewController: UIViewController {
             delegate.impressionViewModel.impressionEdit(text: impressionTextView.text)
         } else {
             print(bucketNo)
-            delegate.impressionViewModel.impressionSave(bucketNo: bucketNo, text: impressionTextView.text)
+            var impression = RealmImpression(value: [0, impressionTextView.text, bucketNo])
+            delegate.impressionViewModel.impressionSave(impression)
         }
         
         dismiss(animated: true, completion: nil)

--- a/iOS/project04/project04/Scene/Impression/ViewModel/ImpressionViewModel.swift
+++ b/iOS/project04/project04/Scene/Impression/ViewModel/ImpressionViewModel.swift
@@ -12,7 +12,7 @@ protocol ImpressionViewModelProtocol {
     var impressionText: String { get set }
     var textChange: ((ImpressionViewModelProtocol)->())? { get set }
     func impressionFetch(bucketNo: Int)
-    func impressionSave(bucketNo: Int, text: String)
+    func impressionSave(_ element: RealmImpression)
     func impressionEdit(text: String)
 }
 
@@ -39,9 +39,9 @@ class ImpressionViewModel: ImpressionViewModelProtocol {
         })
     }
     
-    func impressionSave(bucketNo: Int, text: String) {
-        usecase.save(bucketNo: bucketNo, text: text)
-        impressionText = text
+    func impressionSave(_ element: RealmImpression) {
+        usecase.save(element)
+        impressionText = element.text
     }
     
     func impressionEdit(text: String) {

--- a/iOS/project04/project04/Util/Singleton/NetworkPathMonitor.swift
+++ b/iOS/project04/project04/Util/Singleton/NetworkPathMonitor.swift
@@ -27,6 +27,7 @@ class NetworkStatus {
         self.monitor.pathUpdateHandler = { path in
             if path.status == .satisfied {
                 print("good")
+                TransactionRecorder.shared.execute()
             } else {
                 print("not good")
             }

--- a/iOS/project04/project04/Util/Singleton/NetworkService.swift
+++ b/iOS/project04/project04/Util/Singleton/NetworkService.swift
@@ -45,7 +45,9 @@ class NetworkService {
             if error != nil {
                 completion(.failure(.responseError))
                 semaphore?.signal()
+                return
             }
+            
             guard let response = response as? HTTPURLResponse,
                   (200...299).contains(response.statusCode),
                   let data = data else {

--- a/iOS/project04/project04/Util/Singleton/TransactionRecorder.swift
+++ b/iOS/project04/project04/Util/Singleton/TransactionRecorder.swift
@@ -1,0 +1,39 @@
+//
+//  TransactionRecorder.swift
+//  project04
+//
+//  Created by jaejeon on 2020/12/10.
+//
+
+import Foundation
+import RealmSwift
+
+class TransactionRecorder {
+    static let shared = TransactionRecorder()
+    
+    private init(){}
+    
+    func record(url: String, method: HTTPMethod, data: Data) {
+        let transaction = RealmTransaction(value: [url, method.rawValue, data])
+        do {
+            let realm = try Realm()
+            try realm.write {
+                realm.add(transaction)
+            }
+        } catch {
+            print(error)
+        }
+    }
+    
+    func execute() {
+        var transactions: [RealmTransaction]
+        do {
+            let results = try Realm().objects(RealmTransaction.self)
+            transactions = results.map({ $0 })
+
+        } catch {
+            print(error)
+        }
+        
+    }
+}


### PR DESCRIPTION
## 구현의도
- 오프라인 데이터 싱크를 구현 했습니다.
- TransactionRecorder 가 네트워크가 상태가 오프라인일 때 네트워크 트렌젝션을 기록하고, 네트워크 상태가 온라인이 된다면 기록했던 트렉젝션을 수행합니다.

- 때문에 request를 동기적으로 순차적으로 해야할 이유가 생겼고, 이를 DispatchSemaphore로 해결 했습니다.
- 네트워크 상태 파악은 NWPathMonitor 를 활용했습니다.

## 논의사항
짝프로그래밍을 통해서 수월하게 진행한 것 같은데, 혹시 찾지 못한 버그들을 한번더 찾아봐야 할 것 같아요