### PR TITLE
[SERVER] API 리팩토링

### DIFF
--- a/server/routes/follow/controller.js
+++ b/server/routes/follow/controller.js
@@ -1,5 +1,6 @@
 const { OK, CREATED, BAD_REQUEST } = require('../../config/statusCode').statusCode;
 const followServices = require('../../services/follow');
+const userServices = require('../../services/user');
 
 const userNo = 1;
 
@@ -141,5 +142,24 @@ exports.deleteFollowing = async (req, res, next) => {
     res.status(BAD_REQUEST).json({
       message: '팔로우 삭제 실패',
     });
+  }
+};
+
+/*
+    GET /api/follows/search
+    * 사용자 검색 API
+*/
+
+exports.searchUsers = async (req, res, next) => {
+  try {
+    const { keyword } = req.query;
+    const user = await userServices.searchUser(keyword);
+
+    res.status(OK).json({
+      message: '사용자 검색 성공',
+      data: user,
+    });
+  } catch (error) {
+    next(error);
   }
 };

--- a/server/routes/follow/index.js
+++ b/server/routes/follow/index.js
@@ -8,6 +8,7 @@ router.get('/followed', middlewares.jwtAuth, controller.getFollowedList);
 router.get('/isfollowing', middlewares.jwtAuth, controller.isFollowing);
 router.get('/followingusers', middlewares.jwtAuth, controller.getFollowingUsers);
 router.get('/followedusers', middlewares.jwtAuth, controller.getFollowedUsers);
+router.get('/search', middlewares.jwtAuth, controller.searchUsers);
 router.post('/', middlewares.jwtAuth, controller.setFollowing);
 router.delete('/:no', middlewares.jwtAuth, controller.deleteFollowing);
 

--- a/server/routes/user/controller.js
+++ b/server/routes/user/controller.js
@@ -112,22 +112,3 @@ exports.getUserInfoByNo = async (req, res, next) => {
     next(error);
   }
 };
-
-/*
-    GET /api/users/search
-    * 사용자 검색 API
-*/
-
-exports.searchUsers = async (req, res, next) => {
-  try {
-    const { keyword } = req.query;
-    const user = await userServices.searchUser(keyword);
-
-    res.status(OK).json({
-      message: '사용자 검색 성공',
-      data: user,
-    });
-  } catch (error) {
-    next(error);
-  }
-};

--- a/server/routes/user/index.js
+++ b/server/routes/user/index.js
@@ -6,7 +6,6 @@ router.get('/info', middlewares.jwtAuth, controller.getUserInfo);
 router.get('/info/:no', middlewares.jwtAuth, controller.getUserInfoByNo);
 router.get('/:id', controller.isDuplicated);
 router.get('/', middlewares.jwtAuth, controller.getUsers);
-router.get('/search', middlewares.jwtAuth, controller.searchUsers);
 router.post('/', controller.setUser);
 router.post('/login', middlewares.localAuth, controller.login);
 

--- a/server/services/bucket.js
+++ b/server/services/bucket.js
@@ -54,8 +54,13 @@ exports.updateBucketTitleDesc = async (no, title, description) => {
 
 exports.getBucketWithAchieve = async (no) => {
   const result = await db.selectBucketWithAchieve(no);
-  const temp = { ...result, achieveComment: result['achieve.description'] };
+  const temp = {
+    ...result,
+    achieveNo: result['achieve.no'],
+    achieveComment: result['achieve.description'],
+  };
   delete temp['achieve.description'];
+  delete temp['achieve.no'];
   return temp;
 };
 

--- a/server/services/db/achieve.js
+++ b/server/services/db/achieve.js
@@ -19,14 +19,7 @@ exports.insertAchieve = async ({ description, bucketNo }) => {
 };
 
 exports.updateAchieve = async ({ description, no }) => {
-  const result = await Achieve.update(
-    {
-      description,
-    },
-    {
-      where: { no },
-    }
-  );
+  const result = await Achieve.update({ description }, { where: { no } });
 
   return result;
 };

--- a/server/services/db/bucket.js
+++ b/server/services/db/bucket.js
@@ -63,7 +63,7 @@ exports.selectBucketWithAchieve = async (no) => {
     include: [
       {
         model: Achieve,
-        attributes: ['description'],
+        attributes: ['no', 'description'],
       },
     ],
   });


### PR DESCRIPTION
## 구현의도
- user 라우터에 get method가 많아서 파라미터가 겹칠 경우 다른 API가 호출되는 문제가 종종 발생
- follow에 필요한 사용자 검색 부분을 follow 라우터로 이동
- userServices는 그대로 사용
- 버킷 상세 목록 조회 API 수정
  - 달성 no도 반환되도록 수정
- 달성 소감 수정 API 수정
  - 코드 길이를 줄이기 위해 쿼리 부분 수정 